### PR TITLE
[codex] add training dry-run smoke controls

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -23,6 +23,17 @@ from src.rl_data import load_rl_dataset, run_grpo_preflight, save_preflight_repo
 from src.trainer import KFoldTrainer, LoRATrainer
 
 
+def _positive_int(value: str) -> int:
+    """Parse a positive integer for CLI sample limits."""
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"{value!r} is not an integer") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be >= 1")
+    return parsed
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Train LoRA adapters with MLX (SFT/KFold/GRPO)")
     parser.add_argument("--config", type=str, default="configs/default.yaml", help="Path to config file")
@@ -39,7 +50,136 @@ def parse_args() -> argparse.Namespace:
         choices=["basic", "kfold", "grpo", "grpo_kfold"],
         help="Override training method",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate the resolved plan and dataset counts without loading the model or training",
+    )
+    parser.add_argument(
+        "--max-train-samples",
+        type=_positive_int,
+        help="Limit SFT or RL training samples for smoke runs",
+    )
+    parser.add_argument(
+        "--max-val-samples",
+        type=_positive_int,
+        help="Limit SFT or RL validation samples for smoke runs",
+    )
     return parser.parse_args()
+
+
+def _limit_samples(samples: List[Dict[str, Any]], max_samples: Optional[int], label: str) -> List[Dict[str, Any]]:
+    """Return a deterministic prefix of samples when a smoke-test limit is set."""
+    if max_samples is None:
+        return samples
+
+    limited = samples[:max_samples]
+    print(f"Using {len(limited)}/{len(samples)} {label} samples")
+    return limited
+
+
+def _dataset_plan(path: str, loaded_count: int, used_count: int, exists: bool = True) -> Dict[str, Any]:
+    return {
+        "path": path,
+        "exists": exists,
+        "loaded_samples": loaded_count,
+        "used_samples": used_count,
+    }
+
+
+def run_dry_run(
+    config: Config,
+    training_method: str,
+    *,
+    max_train_samples: Optional[int] = None,
+    max_val_samples: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Build a no-training execution plan from config and available data."""
+    plan: Dict[str, Any] = {
+        "dry_run": True,
+        "model": config.model.name,
+        "training_method": training_method,
+        "batch_size": config.training.batch_size,
+        "epochs": config.training.num_epochs,
+        "output_dir": config.output.dir,
+        "sample_limits": {
+            "max_train_samples": max_train_samples,
+            "max_val_samples": max_val_samples,
+        },
+        "datasets": {},
+    }
+
+    if training_method in {"basic", "kfold"}:
+        train_data = load_dataset(config.data.train_file)
+        train_used = _limit_samples(train_data, max_train_samples, "training")
+        plan["datasets"]["train"] = _dataset_plan(
+            config.data.train_file,
+            loaded_count=len(train_data),
+            used_count=len(train_used),
+        )
+
+        valid_file = Path(config.data.valid_file)
+        valid_used: List[Dict[str, Any]] = []
+        if valid_file.exists():
+            valid_data = load_dataset(valid_file)
+            valid_used = _limit_samples(valid_data, max_val_samples, "validation")
+            plan["datasets"]["valid"] = _dataset_plan(
+                config.data.valid_file,
+                loaded_count=len(valid_data),
+                used_count=len(valid_used),
+            )
+        else:
+            plan["datasets"]["valid"] = _dataset_plan(config.data.valid_file, 0, 0, exists=False)
+
+        if training_method == "kfold" and len(train_used) + len(valid_used) < config.data.kfold_splits:
+            raise ValueError(
+                f"K-Fold dry run needs at least {config.data.kfold_splits} samples after limits"
+            )
+
+        return plan
+
+    if training_method in {"grpo", "grpo_kfold"}:
+        rl_train = load_rl_dataset(config.data.rl_train_file)
+        rl_train_used = _limit_samples(rl_train, max_train_samples, "RL training")
+        plan["datasets"]["rl_train"] = _dataset_plan(
+            config.data.rl_train_file,
+            loaded_count=len(rl_train),
+            used_count=len(rl_train_used),
+        )
+
+        rl_valid_file = Path(config.data.rl_valid_file)
+        rl_valid_used: List[Dict[str, Any]] = []
+        if rl_valid_file.exists():
+            rl_valid = load_rl_dataset(rl_valid_file)
+            rl_valid_used = _limit_samples(rl_valid, max_val_samples, "RL validation")
+            plan["datasets"]["rl_valid"] = _dataset_plan(
+                config.data.rl_valid_file,
+                loaded_count=len(rl_valid),
+                used_count=len(rl_valid_used),
+            )
+        else:
+            plan["datasets"]["rl_valid"] = _dataset_plan(config.data.rl_valid_file, 0, 0, exists=False)
+
+        preflight_source = rl_train_used if training_method == "grpo" else rl_train_used + rl_valid_used
+        if training_method == "grpo_kfold" and len(preflight_source) < config.data.kfold_splits:
+            raise ValueError(
+                f"GRPO K-Fold dry run needs at least {config.data.kfold_splits} samples after limits"
+            )
+
+        _, preflight_report = run_grpo_preflight(
+            data=preflight_source,
+            reward_config=config.reward.to_dict(),
+            min_prompt_length=3,
+            min_reference_length=1,
+            sample_size=config.grpo.preflight_sample_size,
+            seed=config.data.kfold_seed,
+            require_nonzero_variance=config.reward.require_nonzero_variance,
+            min_reward_std=config.grpo.min_reward_std,
+        )
+        plan["grpo_preflight"] = preflight_report
+        return plan
+
+    raise ValueError(f"Unknown training method: {training_method}")
 
 
 def create_model_loader(config: Config):
@@ -105,10 +245,20 @@ def _run_post_eval(
         print(f"Warning: post-training evaluation failed ({exc})")
 
 
-def run_basic_or_kfold(config: Config, training_method: str) -> Dict[str, Any]:
+def run_basic_or_kfold(
+    config: Config,
+    training_method: str,
+    *,
+    max_train_samples: Optional[int] = None,
+    max_val_samples: Optional[int] = None,
+) -> Dict[str, Any]:
     """Run original SFT basic/kfold training methods."""
     print("\nLoading training data...")
-    train_data = load_dataset(config.data.train_file)
+    train_data = _limit_samples(
+        load_dataset(config.data.train_file),
+        max_train_samples,
+        "training",
+    )
     print(f"Loaded {len(train_data)} training examples")
 
     if training_method == "kfold":
@@ -121,7 +271,11 @@ def run_basic_or_kfold(config: Config, training_method: str) -> Dict[str, Any]:
 
         full_data = train_data
         if Path(config.data.valid_file).exists():
-            val_data = load_dataset(config.data.valid_file)
+            val_data = _limit_samples(
+                load_dataset(config.data.valid_file),
+                max_val_samples,
+                "validation",
+            )
             full_data = train_data + val_data
             print(f"Combined train + val data: {len(full_data)} total examples")
 
@@ -163,7 +317,11 @@ def run_basic_or_kfold(config: Config, training_method: str) -> Dict[str, Any]:
 
     val_data = None
     if Path(config.data.valid_file).exists():
-        val_data = load_dataset(config.data.valid_file)
+        val_data = _limit_samples(
+            load_dataset(config.data.valid_file),
+            max_val_samples,
+            "validation",
+        )
         print(f"Loaded {len(val_data)} validation examples")
 
     trainer = LoRATrainer(
@@ -192,10 +350,28 @@ def run_basic_or_kfold(config: Config, training_method: str) -> Dict[str, Any]:
     return trainer.train()
 
 
-def run_grpo(config: Config, config_path: str) -> Dict[str, Any]:
+def run_grpo(
+    config: Config,
+    config_path: str,
+    *,
+    max_train_samples: Optional[int] = None,
+    max_val_samples: Optional[int] = None,
+) -> Dict[str, Any]:
     """Run GRPO single-run training with mandatory preflight + warmup + post-eval."""
-    rl_train = load_rl_dataset(config.data.rl_train_file)
-    rl_valid = load_rl_dataset(config.data.rl_valid_file) if Path(config.data.rl_valid_file).exists() else []
+    rl_train = _limit_samples(
+        load_rl_dataset(config.data.rl_train_file),
+        max_train_samples,
+        "RL training",
+    )
+    rl_valid = (
+        _limit_samples(
+            load_rl_dataset(config.data.rl_valid_file),
+            max_val_samples,
+            "RL validation",
+        )
+        if Path(config.data.rl_valid_file).exists()
+        else []
+    )
 
     preflight_data, preflight_report = run_grpo_preflight(
         data=rl_train,
@@ -305,10 +481,28 @@ def run_grpo(config: Config, config_path: str) -> Dict[str, Any]:
     return stats
 
 
-def run_grpo_kfold(config: Config, config_path: str) -> Dict[str, Any]:
+def run_grpo_kfold(
+    config: Config,
+    config_path: str,
+    *,
+    max_train_samples: Optional[int] = None,
+    max_val_samples: Optional[int] = None,
+) -> Dict[str, Any]:
     """Run GRPO K-Fold training with warmup per fold and automatic post-eval."""
-    rl_train = load_rl_dataset(config.data.rl_train_file)
-    rl_valid = load_rl_dataset(config.data.rl_valid_file) if Path(config.data.rl_valid_file).exists() else []
+    rl_train = _limit_samples(
+        load_rl_dataset(config.data.rl_train_file),
+        max_train_samples,
+        "RL training",
+    )
+    rl_valid = (
+        _limit_samples(
+            load_rl_dataset(config.data.rl_valid_file),
+            max_val_samples,
+            "RL validation",
+        )
+        if Path(config.data.rl_valid_file).exists()
+        else []
+    )
     full_data = rl_train + rl_valid
 
     normalized_data, preflight_report = run_grpo_preflight(
@@ -420,14 +614,40 @@ def main() -> None:
     print(f"Training method: {training_method}")
     print("=" * 70)
 
+    if args.dry_run:
+        stats = run_dry_run(
+            config,
+            training_method,
+            max_train_samples=args.max_train_samples,
+            max_val_samples=args.max_val_samples,
+        )
+        print(json.dumps(stats, indent=2))
+        print("Dry run complete. No model was loaded and no training was started.")
+        return
+
     config.output.ensure_dirs()
 
     if training_method in {"basic", "kfold"}:
-        stats = run_basic_or_kfold(config, training_method)
+        stats = run_basic_or_kfold(
+            config,
+            training_method,
+            max_train_samples=args.max_train_samples,
+            max_val_samples=args.max_val_samples,
+        )
     elif training_method == "grpo":
-        stats = run_grpo(config, args.config)
+        stats = run_grpo(
+            config,
+            args.config,
+            max_train_samples=args.max_train_samples,
+            max_val_samples=args.max_val_samples,
+        )
     elif training_method == "grpo_kfold":
-        stats = run_grpo_kfold(config, args.config)
+        stats = run_grpo_kfold(
+            config,
+            args.config,
+            max_train_samples=args.max_train_samples,
+            max_val_samples=args.max_val_samples,
+        )
     else:
         raise ValueError(f"Unknown training method: {training_method}")
 

--- a/tests/test_train_cli_grpo.py
+++ b/tests/test_train_cli_grpo.py
@@ -3,15 +3,19 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 import sys
 import types
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from src.config import Config
 
 
 def _install_fake_mlx(monkeypatch):
     fake_mx_core = types.ModuleType("mlx.core")
+    fake_mx_core.array = object
     fake_nn = types.ModuleType("mlx.nn")
     fake_nn.Module = object
     fake_optim = types.ModuleType("mlx.optimizers")
@@ -48,13 +52,13 @@ def test_cli_dispatches_grpo(monkeypatch, tmp_path):
 
     called = {"grpo": 0}
 
-    def fake_grpo(config, config_path):
+    def fake_grpo(config, config_path, **kwargs):
         called["grpo"] += 1
         return {"mode": "grpo"}
 
     monkeypatch.setattr(module, "run_grpo", fake_grpo)
-    monkeypatch.setattr(module, "run_basic_or_kfold", lambda *_: (_ for _ in ()).throw(AssertionError("unexpected")))
-    monkeypatch.setattr(module, "run_grpo_kfold", lambda *_: (_ for _ in ()).throw(AssertionError("unexpected")))
+    monkeypatch.setattr(module, "run_basic_or_kfold", lambda *_, **__: (_ for _ in ()).throw(AssertionError("unexpected")))
+    monkeypatch.setattr(module, "run_grpo_kfold", lambda *_, **__: (_ for _ in ()).throw(AssertionError("unexpected")))
 
     monkeypatch.setattr(sys, "argv", ["train.py", "--config", str(cfg_path), "--training-method", "grpo"])
     module.main()
@@ -71,15 +75,104 @@ def test_cli_dispatches_grpo_kfold(monkeypatch, tmp_path):
 
     called = {"grpo_kfold": 0}
 
-    def fake_grpo_kfold(config, config_path):
+    def fake_grpo_kfold(config, config_path, **kwargs):
         called["grpo_kfold"] += 1
         return {"mode": "grpo_kfold"}
 
     monkeypatch.setattr(module, "run_grpo_kfold", fake_grpo_kfold)
-    monkeypatch.setattr(module, "run_basic_or_kfold", lambda *_: (_ for _ in ()).throw(AssertionError("unexpected")))
-    monkeypatch.setattr(module, "run_grpo", lambda *_: (_ for _ in ()).throw(AssertionError("unexpected")))
+    monkeypatch.setattr(module, "run_basic_or_kfold", lambda *_, **__: (_ for _ in ()).throw(AssertionError("unexpected")))
+    monkeypatch.setattr(module, "run_grpo", lambda *_, **__: (_ for _ in ()).throw(AssertionError("unexpected")))
 
     monkeypatch.setattr(sys, "argv", ["train.py", "--config", str(cfg_path), "--training-method", "grpo_kfold"])
     module.main()
 
     assert called["grpo_kfold"] == 1
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, str]]) -> None:
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n")
+
+
+def test_cli_dry_run_reports_limited_sft_plan_without_training(monkeypatch, tmp_path, capsys):
+    module = _load_train_module(monkeypatch)
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    train_path = data_dir / "train.jsonl"
+    valid_path = data_dir / "valid.jsonl"
+    _write_jsonl(train_path, [{"text": f"train {i}"} for i in range(3)])
+    _write_jsonl(valid_path, [{"text": f"valid {i}"} for i in range(2)])
+
+    cfg = Config()
+    cfg.data.train_file = str(train_path)
+    cfg.data.valid_file = str(valid_path)
+    cfg.output.dir = str(tmp_path / "outputs")
+    cfg_path = tmp_path / "config.yaml"
+    cfg.to_yaml(str(cfg_path))
+
+    monkeypatch.setattr(module, "run_basic_or_kfold", lambda *_, **__: (_ for _ in ()).throw(AssertionError("unexpected")))
+    monkeypatch.setattr(module, "run_grpo", lambda *_, **__: (_ for _ in ()).throw(AssertionError("unexpected")))
+    monkeypatch.setattr(module, "run_grpo_kfold", lambda *_, **__: (_ for _ in ()).throw(AssertionError("unexpected")))
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "train.py",
+            "--config",
+            str(cfg_path),
+            "--dry-run",
+            "--max-train-samples",
+            "2",
+            "--max-val-samples",
+            "1",
+        ],
+    )
+
+    module.main()
+
+    output = capsys.readouterr().out
+    assert "Dry run complete" in output
+    assert '"training_method": "basic"' in output
+    assert '"loaded_samples": 3' in output
+    assert '"used_samples": 2' in output
+    assert '"loaded_samples": 2' in output
+    assert '"used_samples": 1' in output
+
+
+def test_cli_passes_sample_limits_to_grpo(monkeypatch, tmp_path):
+    module = _load_train_module(monkeypatch)
+
+    cfg = Config()
+    cfg_path = tmp_path / "config.yaml"
+    cfg.to_yaml(str(cfg_path))
+
+    captured = {}
+
+    def fake_grpo(config, config_path, **kwargs):
+        captured.update(kwargs)
+        return {"mode": "grpo"}
+
+    monkeypatch.setattr(module, "run_grpo", fake_grpo)
+    monkeypatch.setattr(module, "run_basic_or_kfold", lambda *_, **__: (_ for _ in ()).throw(AssertionError("unexpected")))
+    monkeypatch.setattr(module, "run_grpo_kfold", lambda *_, **__: (_ for _ in ()).throw(AssertionError("unexpected")))
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "train.py",
+            "--config",
+            str(cfg_path),
+            "--training-method",
+            "grpo",
+            "--max-train-samples",
+            "4",
+            "--max-val-samples",
+            "2",
+        ],
+    )
+    module.main()
+
+    assert captured["max_train_samples"] == 4
+    assert captured["max_val_samples"] == 2


### PR DESCRIPTION
## Summary
- add --dry-run to print a resolved training plan without loading a model or starting training
- add --max-train-samples and --max-val-samples for deterministic SFT/GRPO smoke runs
- cover dry-run and sample-limit dispatch behavior in CLI tests

## Why
This makes it safe to validate tiny batches before running larger MLX models such as mlx-community/Qwen3.5-4B-OptiQ-4bit.

Closes #5.

## Validation
- pytest -q
- ruff check scripts/train.py tests/test_train_cli_grpo.py
- git diff --check
- python3 scripts/train.py --config configs/default.yaml --model mlx-community/Qwen3.5-4B-OptiQ-4bit --data data/processed --output work-tmp/dry-run-output --epochs 1 --batch-size 1 --max-train-samples 2 --max-val-samples 1 --dry-run