### PR TITLE
[codex] align Qwen default prompt template

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -75,9 +75,10 @@ data:
   rl_valid_file: "data/processed/rl_valid.jsonl"
   rl_eval_file: "data/processed/rl_eval.jsonl"
   prompt_template: |
-    <|begin_of_text|><|start_header_id|>user<|end_header_id|>
-    {instruction}<|eot_id|><|start_header_id|>assistant<|end_header_id|>
-    {response}<|eot_id|>
+    <|im_start|>user
+    {instruction}<|im_end|>
+    <|im_start|>assistant
+    {response}<|im_end|>
   training_method: "basic"
   kfold_splits: 5
   kfold_seed: 42

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -16,7 +16,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 # Import config classes directly (no MLX dependency)
 from src.config import (
     Config, LoRAConfig, TrainingConfig, GRPOConfig, RewardConfig, ModelConfig,
-    DataConfig, OutputConfig, HuggingFaceConfig
+    OutputConfig,
 )
 
 # Import data_utils functions directly
@@ -155,6 +155,18 @@ class TestConfig:
         
         assert loaded.lora.rank == 32
         assert loaded.training.learning_rate == 2e-5
+
+    def test_default_yaml_uses_qwen_prompt_tokens_for_qwen_model(self):
+        """The shipped Qwen default config should not inject Llama-only tokens."""
+        config = Config.from_yaml("configs/default.yaml")
+
+        if "qwen" not in config.model.name.lower():
+            pytest.skip("Default config no longer uses a Qwen-family model")
+
+        assert config.data.prompt_template is not None
+        assert "<|im_start|>" in config.data.prompt_template
+        assert "<|start_header_id|>" not in config.data.prompt_template
+        assert "<|begin_of_text|>" not in config.data.prompt_template
 
 
 class TestOutputConfig:


### PR DESCRIPTION
## Summary
- replace the Llama-style default prompt template with Qwen chat delimiters in configs/default.yaml
- add a regression test that prevents Qwen defaults from using Llama-only tokens
- remove unused imports from the touched config test module

## Why
The default config selects Qwen/Qwen3-0.6B, so using Llama-specific special tokens can hurt fine-tuning quality and smoke-test fidelity for Qwen-family MLX models.

Closes #7.

## Validation
- pytest tests/test_core.py::TestConfig::test_default_yaml_uses_qwen_prompt_tokens_for_qwen_model -q
- python3 config parse assertion for configs/default.yaml
- ruff check tests/test_core.py
- pytest -q
- git diff --check
