### PR TITLE
[codex] include GRPO training mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A powerful, user-friendly engine for fine-tuning LLM models using LoRA and MLX o
 ## ✨ Features
 
 - 🚀 **Fine-tuning with LoRA**: Efficient training using Low-Rank Adaptation
+- 🧠 **GRPO Reinforcement Learning**: Reward-driven post-training with rule-based rewards
 - 🍎 **MLX Optimized**: Leverages Apple Silicon hardware (M1/M2/M3) to the fullest
 - 🎨 **Streamlit UI**: Web interface with Simple/Advanced modes
 - 🤗 **Hugging Face Integration**: Download and upload models directly from/to the HF Hub
@@ -74,6 +75,19 @@ python scripts/train.py \
     --data data/processed
 ```
 
+#### 2b. Train with GRPO (RL)
+
+```bash
+# Prepare prompt/reference RL files
+python scripts/prepare_data.py \
+    --mode grpo \
+    --input data/raw/dataset.json \
+    --output data/processed
+
+# Run GRPO + KFold from config
+python scripts/train.py --config configs/current.yaml --training-method grpo_kfold
+```
+
 #### 3. Upload to Hugging Face
 
 ```bash
@@ -108,6 +122,7 @@ Enable to use Qwen3-0.6B for intelligent Q&A or summary generation.
 |------|-------------|
 | 🎯 Simple | Choose from presets: Quick Test, Balanced, High Quality, Maximum |
 | ⚙️ Advanced | Full control over LoRA rank, learning rate, epochs, etc. |
+| 🧠 GRPO | Reward-based RL mode with preflight validation, SFT warmup, and post-eval |
 
 ### HuggingFace Upload Page
 
@@ -204,6 +219,18 @@ Using models under 1B parameters is highly recommended for:
 ]
 ```
 
+### GRPO JSONL (Prompt-Reference)
+
+```json
+{"prompt": "Solve: 2+2", "reference": "4", "metadata": {"keywords": ["4"]}}
+{"prompt": "Return valid JSON with keys a,b", "reference": "{\"a\":1,\"b\":2}", "metadata": {"keywords": ["a", "b"]}}
+```
+
+Required fields for GRPO:
+- `prompt`: input shown to policy.
+- `reference`: target answer used by reward rules.
+- `metadata` (optional): extra context for rule-based rewards, e.g. `keywords`.
+
 ### Raw Text
 
 Any `.txt` or `.md` file. The system will:
@@ -215,6 +242,7 @@ Any `.txt` or `.md` file. The system will:
 
 - [LoRA: Low-Rank Adaptation of Large Language Models](https://arxiv.org/abs/2106.09685)
 - [MLX: Machine Learning on Apple Silicon](https://ml-explore.github.io/mlx/)
+- [PPO: Proximal Policy Optimization Algorithms](https://arxiv.org/abs/1707.06347)
 
 ## 🔗 Useful Links
 

--- a/app.py
+++ b/app.py
@@ -2088,10 +2088,13 @@ def render_simple_mode(config):
     
     training_method = st.radio(
         "Select training approach:",
-        options=["basic", "kfold"],
+        options=["basic", "kfold", "grpo", "grpo_kfold"],
+        index=["basic", "kfold", "grpo", "grpo_kfold"].index(getattr(config.data, "training_method", "basic")) if getattr(config.data, "training_method", "basic") in ["basic", "kfold", "grpo", "grpo_kfold"] else 0,
         format_func=lambda x: {
             "basic": "📈 Basic (Single Split) — Standard train/validation split",
-            "kfold": "🔄 K-Fold Cross-Validation — Multiple splits for robust evaluation"
+            "kfold": "🔄 K-Fold Cross-Validation — Multiple splits for robust evaluation",
+            "grpo": "🧠 GRPO (RL) — Reward-driven policy optimization",
+            "grpo_kfold": "🧪 GRPO + K-Fold — RL with robust cross-validation",
         }[x],
         horizontal=True,
         key="training_method_selector",
@@ -2099,7 +2102,7 @@ def render_simple_mode(config):
     )
     config.data.training_method = training_method
     
-    if training_method == "kfold":
+    if training_method in {"kfold", "grpo_kfold"}:
         col1, col2 = st.columns([1, 2])
         with col1:
             config.data.kfold_splits = st.slider(
@@ -2117,6 +2120,21 @@ def render_simple_mode(config):
             - **Benefit:** More reliable performance estimates, reduced overfitting risk
             - **Best for:** Small datasets or when you need confidence in model performance
             """)
+
+    if training_method in {"grpo", "grpo_kfold"}:
+        st.markdown("### 🎯 GRPO Reward Configuration")
+        col1, col2, col3 = st.columns(3)
+        with col1:
+            config.grpo.group_size = st.slider("Group Size", min_value=2, max_value=8, value=config.grpo.group_size)
+            config.grpo.clip_epsilon = st.slider("Clip Epsilon", min_value=0.05, max_value=0.4, value=float(config.grpo.clip_epsilon), step=0.05)
+        with col2:
+            config.grpo.beta_kl = st.number_input("KL Beta", min_value=0.0, max_value=1.0, value=float(config.grpo.beta_kl), step=0.01, format="%.3f")
+            config.grpo.warmup_epochs = st.number_input("Warmup SFT Epochs", min_value=0, max_value=10, value=int(config.grpo.warmup_epochs))
+        with col3:
+            config.grpo.max_generation_tokens = st.slider("Max Gen Tokens", min_value=32, max_value=512, value=int(config.grpo.max_generation_tokens), step=32)
+            config.reward.pass_threshold = st.slider("Reward Pass Threshold", min_value=0.0, max_value=1.0, value=float(config.reward.pass_threshold), step=0.05)
+
+        st.caption(f"RL files: train=`{config.data.rl_train_file}`, valid=`{config.data.rl_valid_file}`, eval=`{config.data.rl_eval_file}`")
     
     # Optional: Quick settings adjustments
     with st.expander("🔧 Quick Adjustments (Optional)"):
@@ -2278,10 +2296,34 @@ def render_advanced_mode(config):
                 max_value=500,
                 value=config.training.logging_steps
             )
+
+        st.markdown("### Training Method")
+        config.data.training_method = st.selectbox(
+            "Method",
+            options=["basic", "kfold", "grpo", "grpo_kfold"],
+            index=["basic", "kfold", "grpo", "grpo_kfold"].index(getattr(config.data, "training_method", "basic")),
+            help="Choose supervised fine-tuning or reward-based GRPO",
+        )
+
+        if config.data.training_method in {"grpo", "grpo_kfold"}:
+            st.markdown("### GRPO Settings")
+            g1, g2, g3 = st.columns(3)
+            with g1:
+                config.grpo.group_size = st.number_input("Group Size", min_value=2, max_value=16, value=int(config.grpo.group_size))
+                config.grpo.clip_epsilon = st.number_input("Clip Epsilon", min_value=0.01, max_value=1.0, value=float(config.grpo.clip_epsilon), step=0.01, format="%.2f")
+                config.grpo.beta_kl = st.number_input("KL Beta", min_value=0.0, max_value=2.0, value=float(config.grpo.beta_kl), step=0.01, format="%.3f")
+            with g2:
+                config.grpo.warmup_epochs = st.number_input("Warmup Epochs", min_value=0, max_value=50, value=int(config.grpo.warmup_epochs))
+                config.grpo.max_generation_tokens = st.number_input("Max Generation Tokens", min_value=16, max_value=2048, value=int(config.grpo.max_generation_tokens))
+                config.grpo.temperature = st.number_input("Temperature", min_value=0.0, max_value=2.0, value=float(config.grpo.temperature), step=0.1, format="%.2f")
+            with g3:
+                config.reward.pass_threshold = st.number_input("Reward Pass Threshold", min_value=0.0, max_value=1.0, value=float(config.reward.pass_threshold), step=0.05, format="%.2f")
+                config.reward.min_response_length = st.number_input("Reward Min Length", min_value=0, max_value=4096, value=int(config.reward.min_response_length))
+                config.reward.max_response_length = st.number_input("Reward Max Length", min_value=1, max_value=8192, value=int(config.reward.max_response_length))
     
     with tab3:
         st.markdown("### Data Paths")
-        col1, col2 = st.columns(2)
+        col1, col2, col3 = st.columns(3)
         with col1:
             config.data.train_file = st.text_input(
                 "📄 Training File",
@@ -2291,6 +2333,24 @@ def render_advanced_mode(config):
             config.data.valid_file = st.text_input(
                 "📄 Validation File",
                 value=config.data.valid_file
+            )
+        with col3:
+            config.data.rl_eval_file = st.text_input(
+                "📄 RL Eval File",
+                value=getattr(config.data, "rl_eval_file", "data/processed/rl_eval.jsonl")
+            )
+
+        st.markdown("### RL Data Paths")
+        r1, r2 = st.columns(2)
+        with r1:
+            config.data.rl_train_file = st.text_input(
+                "🧠 RL Train File",
+                value=getattr(config.data, "rl_train_file", "data/processed/rl_train.jsonl")
+            )
+        with r2:
+            config.data.rl_valid_file = st.text_input(
+                "🧠 RL Valid File",
+                value=getattr(config.data, "rl_valid_file", "data/processed/rl_valid.jsonl")
             )
         
         st.markdown("### Output Directories")
@@ -2333,11 +2393,17 @@ def render_execute_section(config):
     st.markdown('<h2 class="section-header">▶️ Start Training</h2>', unsafe_allow_html=True)
     
     # Pre-flight checks
-    train_exists = Path(config.data.train_file).exists()
-    
-    if not train_exists:
-        st.error("❌ Training data not found. Please prepare your data first.")
-        return
+    training_method = getattr(config.data, "training_method", "basic")
+    if training_method in {"grpo", "grpo_kfold"}:
+        train_exists = Path(config.data.rl_train_file).exists()
+        if not train_exists:
+            st.error("❌ RL training data not found. Prepare `rl_train.jsonl` first or run prepare_data with `--mode grpo`.")
+            return
+    else:
+        train_exists = Path(config.data.train_file).exists()
+        if not train_exists:
+            st.error("❌ Training data not found. Please prepare your data first.")
+            return
     
     # Summary before training
     with st.expander("📋 Training Summary", expanded=True):
@@ -2358,6 +2424,11 @@ def render_execute_section(config):
             **Batch Size:** {config.training.batch_size}  
             **Learning Rate:** {config.training.learning_rate:.0e}
             """)
+        st.markdown(f"**Method:** `{training_method}`")
+        if training_method in {"grpo", "grpo_kfold"}:
+            st.markdown(
+                f"**GRPO:** group={config.grpo.group_size}, clip={config.grpo.clip_epsilon}, β_kl={config.grpo.beta_kl}, warmup={config.grpo.warmup_epochs} epoch(s)"
+            )
 
     # Action buttons
     st.markdown("### ▶️ Start Training")
@@ -2725,13 +2796,19 @@ def render_training_metrics_panel():
     step_entries = []
     eval_entries = []
     epoch_entries = []
+    grpo_start_info = None
+    grpo_end_info = None
+    grpo_step_entries = []
+    grpo_eval_entries = []
     
     # K-Fold specific entries
     kfold_start_info = None
     kfold_end_info = None
+    grpo_kfold_end_info = None
     fold_entries = []  # List of {fold, start, end} dicts
     current_fold = None
     is_kfold = False
+    is_grpo = False
     
     if log_file.exists():
         try:
@@ -2752,14 +2829,36 @@ def render_training_metrics_panel():
                             eval_entries.append(entry)
                         elif entry_type == "epoch_end":
                             epoch_entries.append(entry)
+                        elif entry_type == "grpo_start":
+                            grpo_start_info = entry
+                            is_grpo = True
+                        elif entry_type == "grpo_end":
+                            grpo_end_info = entry
+                        elif entry_type == "grpo_step":
+                            grpo_step_entries.append(entry)
+                            is_grpo = True
+                        elif entry_type == "grpo_eval":
+                            grpo_eval_entries.append(entry)
+                            is_grpo = True
                         elif entry_type == "kfold_start":
                             kfold_start_info = entry
                             is_kfold = True
                         elif entry_type == "kfold_end":
                             kfold_end_info = entry
+                        elif entry_type == "grpo_kfold_end":
+                            grpo_kfold_end_info = entry
+                            is_kfold = True
+                            is_grpo = True
                         elif entry_type == "fold_start":
                             current_fold = {"fold": entry.get("fold"), "start": entry, "end": None}
+                        elif entry_type == "grpo_fold_start":
+                            current_fold = {"fold": entry.get("fold"), "start": entry, "end": None}
                         elif entry_type == "fold_end":
+                            if current_fold:
+                                current_fold["end"] = entry
+                                fold_entries.append(current_fold)
+                                current_fold = None
+                        elif entry_type == "grpo_fold_end":
                             if current_fold:
                                 current_fold["end"] = entry
                                 fold_entries.append(current_fold)
@@ -2767,7 +2866,7 @@ def render_training_metrics_panel():
         except Exception as e:
             st.warning(f"Could not load training logs: {e}")
     
-    has_logs = len(step_entries) > 0
+    has_logs = len(step_entries) > 0 or len(grpo_step_entries) > 0
     
     col1, col2 = st.columns([2, 3])
     
@@ -2799,6 +2898,27 @@ def render_training_metrics_panel():
             val_samples = train_start_info.get("val_samples", 0)
             if train_samples or val_samples:
                 st.markdown(f"**📊 Data:** {train_samples} train / {val_samples} validation samples")
+        elif grpo_start_info:
+            grpo_cfg = grpo_start_info.get("grpo_config", {})
+            log_lora = grpo_start_info.get("lora_config", {})
+            model_name = grpo_start_info.get("model_name", config.model.name)
+
+            st.markdown(f"""
+            | Parameter | Value |
+            |-----------|-------|
+            | **Model** | `{model_name}` |
+            | **LoRA Rank** | {log_lora.get('rank', config.lora.rank)} |
+            | **LoRA Alpha** | {log_lora.get('alpha', config.lora.alpha)} |
+            | **GRPO Group Size** | {grpo_cfg.get('group_size', config.grpo.group_size)} |
+            | **Clip Epsilon** | {grpo_cfg.get('clip_epsilon', config.grpo.clip_epsilon)} |
+            | **KL Beta** | {grpo_cfg.get('beta_kl', config.grpo.beta_kl)} |
+            | **Max Gen Tokens** | {grpo_cfg.get('max_generation_tokens', config.grpo.max_generation_tokens)} |
+            | **Temperature** | {grpo_cfg.get('temperature', config.grpo.temperature)} |
+            """)
+            train_samples = grpo_start_info.get("train_samples", 0)
+            val_samples = grpo_start_info.get("val_samples", 0)
+            if train_samples or val_samples:
+                st.markdown(f"**📊 RL Data:** {train_samples} train / {val_samples} validation samples")
         else:
             st.markdown(f"""
             | Parameter | Value |
@@ -2827,7 +2947,10 @@ def render_training_metrics_panel():
         
         # Try to load training state from best/final checkpoint
         for cp_name in ["final", "best"]:
-            state_path = PROJECT_ROOT / "outputs" / "checkpoints" / cp_name / "trainer_state.json"
+            state_dir = PROJECT_ROOT / "outputs" / "checkpoints" / cp_name
+            trainer_state_path = state_dir / "trainer_state.json"
+            grpo_state_path = state_dir / "grpo_state.json"
+            state_path = trainer_state_path if trainer_state_path.exists() else grpo_state_path
             if state_path.exists():
                 try:
                     with open(state_path, "r") as f:
@@ -2840,10 +2963,13 @@ def render_training_metrics_panel():
                         st.metric("Epochs Completed", state.get("epoch", "N/A") + 1 if isinstance(state.get("epoch"), int) else "N/A")
                     with col_c:
                         best_loss = state.get("best_val_loss")
-                        if best_loss and best_loss != float("inf"):
+                        best_reward = state.get("best_eval_reward")
+                        if best_reward is not None:
+                            st.metric("Best Eval Reward", f"{best_reward:.4f}")
+                        elif best_loss and best_loss != float("inf"):
                             st.metric("Best Val Loss", f"{best_loss:.4f}")
                         else:
-                            st.metric("Best Val Loss", "N/A")
+                            st.metric("Best Metric", "N/A")
                     
                     st.success(f"✅ Loaded training state from **{cp_name}** checkpoint")
                     break
@@ -2856,42 +2982,60 @@ def render_training_metrics_panel():
         st.markdown("### 📉 Loss Curve")
         if has_logs:
             import pandas as pd
-            
-            # Create dataframe for step losses
-            steps = [e["step"] for e in step_entries]
-            losses = [e["loss"] for e in step_entries]
-            
-            df_loss = pd.DataFrame({
-                "Step": steps,
-                "Training Loss": losses,
-            })
-            
-            # Add validation losses if available
-            if eval_entries:
-                eval_steps = [e["step"] for e in eval_entries]
-                eval_losses = [e["val_loss"] for e in eval_entries]
-                df_val = pd.DataFrame({
-                    "Step": eval_steps,
-                    "Validation Loss": eval_losses,
+
+            if grpo_step_entries:
+                df_loss = pd.DataFrame({
+                    "Step": [e["step"] for e in grpo_step_entries],
+                    "Total Loss": [e.get("total_loss", 0.0) for e in grpo_step_entries],
+                    "Policy Loss": [e.get("policy_loss", 0.0) for e in grpo_step_entries],
+                    "KL Loss": [e.get("kl_loss", 0.0) for e in grpo_step_entries],
                 })
-                # Merge with training losses
-                df_loss = df_loss.merge(df_val, on="Step", how="outer").sort_values("Step")
-            
-            # Display loss chart
-            st.line_chart(df_loss.set_index("Step"))
-            
-            # Show epoch markers
-            if epoch_entries:
-                epoch_info = ", ".join([f"Epoch {e['epoch']+1}: step {e['global_step']}" for e in epoch_entries])
-                st.caption(f"📌 Epoch markers: {epoch_info}")
+                st.line_chart(df_loss.set_index("Step"))
+
+                st.markdown("### 🏆 Reward Curve")
+                df_reward = pd.DataFrame({
+                    "Step": [e["step"] for e in grpo_step_entries],
+                    "Mean Reward": [e.get("mean_reward", 0.0) for e in grpo_step_entries],
+                    "Reward Std": [e.get("std_reward", 0.0) for e in grpo_step_entries],
+                })
+                st.line_chart(df_reward.set_index("Step"))
+            else:
+                # Create dataframe for step losses
+                steps = [e["step"] for e in step_entries]
+                losses = [e["loss"] for e in step_entries]
+
+                df_loss = pd.DataFrame({
+                    "Step": steps,
+                    "Training Loss": losses,
+                })
+
+                # Add validation losses if available
+                if eval_entries:
+                    eval_steps = [e["step"] for e in eval_entries]
+                    eval_losses = [e["val_loss"] for e in eval_entries]
+                    df_val = pd.DataFrame({
+                        "Step": eval_steps,
+                        "Validation Loss": eval_losses,
+                    })
+                    # Merge with training losses
+                    df_loss = df_loss.merge(df_val, on="Step", how="outer").sort_values("Step")
+
+                # Display loss chart
+                st.line_chart(df_loss.set_index("Step"))
+
+                # Show epoch markers
+                if epoch_entries:
+                    epoch_info = ", ".join([f"Epoch {e['epoch']+1}: step {e['global_step']}" for e in epoch_entries])
+                    st.caption(f"📌 Epoch markers: {epoch_info}")
         else:
             st.info("💡 Loss curve visualization requires training log data. Run training with the built-in trainer to generate detailed logs.")
         
         # Learning Rate Curve
-        if has_logs:
+        if has_logs and (step_entries or grpo_step_entries):
             st.markdown("### 📈 Learning Rate")
-            lr_steps = [e["step"] for e in step_entries]
-            lr_values = [e["learning_rate"] for e in step_entries]
+            source_steps = grpo_step_entries if grpo_step_entries else step_entries
+            lr_steps = [e["step"] for e in source_steps]
+            lr_values = [e.get("learning_rate", e.get("lr", 0.0)) for e in source_steps]
             
             import pandas as pd
             df_lr = pd.DataFrame({
@@ -2924,17 +3068,52 @@ def render_training_metrics_panel():
             import pandas as pd
             
             # Create comprehensive metrics table
-            df_metrics = pd.DataFrame(step_entries)
-            cols_to_show = ["step", "epoch", "loss", "learning_rate", "tokens_per_second", "elapsed_time"]
+            metrics_source = grpo_step_entries if grpo_step_entries else step_entries
+            df_metrics = pd.DataFrame(metrics_source)
+            cols_to_show = (
+                ["step", "epoch", "policy_loss", "kl_loss", "total_loss", "mean_reward", "std_reward", "learning_rate", "tokens_per_second", "elapsed_time"]
+                if grpo_step_entries
+                else ["step", "epoch", "loss", "learning_rate", "tokens_per_second", "elapsed_time"]
+            )
             available_cols = [c for c in cols_to_show if c in df_metrics.columns]
             
             if available_cols:
                 df_display = df_metrics[available_cols].copy()
-                df_display.columns = ["Step", "Epoch", "Loss", "Learning Rate", "Tokens/sec", "Time (s)"][:len(available_cols)]
+                if grpo_step_entries:
+                    rename_map = {
+                        "step": "Step",
+                        "epoch": "Epoch",
+                        "policy_loss": "Policy Loss",
+                        "kl_loss": "KL Loss",
+                        "total_loss": "Total Loss",
+                        "mean_reward": "Mean Reward",
+                        "std_reward": "Reward Std",
+                        "learning_rate": "Learning Rate",
+                        "tokens_per_second": "Tokens/sec",
+                        "elapsed_time": "Time (s)",
+                    }
+                else:
+                    rename_map = {
+                        "step": "Step",
+                        "epoch": "Epoch",
+                        "loss": "Loss",
+                        "learning_rate": "Learning Rate",
+                        "tokens_per_second": "Tokens/sec",
+                        "elapsed_time": "Time (s)",
+                    }
+                df_display = df_display.rename(columns=rename_map)
                 
                 # Format numeric columns
                 if "Loss" in df_display.columns:
                     df_display["Loss"] = df_display["Loss"].apply(lambda x: f"{x:.4f}")
+                if "Policy Loss" in df_display.columns:
+                    df_display["Policy Loss"] = df_display["Policy Loss"].apply(lambda x: f"{x:.4f}")
+                if "KL Loss" in df_display.columns:
+                    df_display["KL Loss"] = df_display["KL Loss"].apply(lambda x: f"{x:.4f}")
+                if "Total Loss" in df_display.columns:
+                    df_display["Total Loss"] = df_display["Total Loss"].apply(lambda x: f"{x:.4f}")
+                if "Mean Reward" in df_display.columns:
+                    df_display["Mean Reward"] = df_display["Mean Reward"].apply(lambda x: f"{x:.4f}")
                 if "Learning Rate" in df_display.columns:
                     df_display["Learning Rate"] = df_display["Learning Rate"].apply(lambda x: f"{x:.2e}")
                 if "Time (s)" in df_display.columns:
@@ -2943,13 +3122,14 @@ def render_training_metrics_panel():
                 st.dataframe(df_display, width="stretch", hide_index=True)
             
             # Training summary
-            if train_end_info:
+            if train_end_info or grpo_end_info:
                 st.markdown("#### 🏁 Training Summary")
                 col1, col2, col3, col4 = st.columns(4)
+                summary_info = grpo_end_info if grpo_end_info else train_end_info
                 with col1:
-                    st.metric("Total Steps", train_end_info.get("total_steps", "N/A"))
+                    st.metric("Total Steps", summary_info.get("total_steps", "N/A"))
                 with col2:
-                    total_time = train_end_info.get("total_time", 0)
+                    total_time = summary_info.get("total_time", 0)
                     if total_time:
                         mins = int(total_time // 60)
                         secs = int(total_time % 60)
@@ -2957,14 +3137,22 @@ def render_training_metrics_panel():
                     else:
                         st.metric("Training Time", "N/A")
                 with col3:
-                    final_loss = train_end_info.get("final_loss")
-                    st.metric("Final Loss", f"{final_loss:.4f}" if final_loss else "N/A")
-                with col4:
-                    best_val = train_end_info.get("best_val_loss")
-                    if best_val and best_val != float("inf"):
-                        st.metric("Best Val Loss", f"{best_val:.4f}")
+                    if grpo_end_info:
+                        final_loss = summary_info.get("final_total_loss")
+                        st.metric("Final Total Loss", f"{final_loss:.4f}" if final_loss is not None else "N/A")
                     else:
-                        st.metric("Best Val Loss", "N/A")
+                        final_loss = summary_info.get("final_loss")
+                        st.metric("Final Loss", f"{final_loss:.4f}" if final_loss else "N/A")
+                with col4:
+                    if grpo_end_info:
+                        best_reward = summary_info.get("best_eval_reward")
+                        st.metric("Best Eval Reward", f"{best_reward:.4f}" if best_reward is not None else "N/A")
+                    else:
+                        best_val = summary_info.get("best_val_loss")
+                        if best_val and best_val != float("inf"):
+                            st.metric("Best Val Loss", f"{best_val:.4f}")
+                        else:
+                            st.metric("Best Val Loss", "N/A")
     
     # K-Fold Cross-Validation Results Section
     if is_kfold and (kfold_end_info or fold_entries):
@@ -2972,7 +3160,7 @@ def render_training_metrics_panel():
         st.markdown('<h3 class="section-header">🔄 K-Fold Cross-Validation Results</h3>', unsafe_allow_html=True)
         
         # Try to load kfold summary file
-        kfold_summary_path = PROJECT_ROOT / "outputs" / "kfold_summary.json"
+        kfold_summary_path = PROJECT_ROOT / "outputs" / ("grpo_kfold_summary.json" if is_grpo else "kfold_summary.json")
         kfold_summary = None
         if kfold_summary_path.exists():
             try:
@@ -2983,24 +3171,36 @@ def render_training_metrics_panel():
         
         # Display summary metrics
         if kfold_summary or kfold_end_info:
-            summary_data = kfold_summary or kfold_end_info
+            summary_data = kfold_summary or grpo_kfold_end_info or kfold_end_info
             
             col1, col2, col3, col4 = st.columns(4)
             with col1:
                 k = summary_data.get("k", len(fold_entries))
                 st.metric("Number of Folds", k)
             with col2:
-                avg_loss = summary_data.get("avg_final_loss", 0)
-                std_loss = summary_data.get("std_final_loss", 0)
-                st.metric("Avg Final Loss", f"{avg_loss:.4f} ± {std_loss:.4f}")
+                if is_grpo:
+                    avg_reward = summary_data.get("avg_best_reward", 0)
+                    std_reward = summary_data.get("std_best_reward", 0)
+                    st.metric("Avg Best Reward", f"{avg_reward:.4f} ± {std_reward:.4f}")
+                else:
+                    avg_loss = summary_data.get("avg_final_loss", 0)
+                    std_loss = summary_data.get("std_final_loss", 0)
+                    st.metric("Avg Final Loss", f"{avg_loss:.4f} ± {std_loss:.4f}")
             with col3:
-                avg_val = summary_data.get("avg_val_loss", 0)
-                std_val = summary_data.get("std_val_loss", 0)
-                st.metric("Avg Val Loss", f"{avg_val:.4f} ± {std_val:.4f}")
+                if is_grpo:
+                    total_time = summary_data.get("total_time", 0)
+                    mins = int(total_time // 60) if total_time else 0
+                    secs = int(total_time % 60) if total_time else 0
+                    st.metric("Total Time", f"{mins}m {secs}s" if total_time else "N/A")
+                else:
+                    avg_val = summary_data.get("avg_val_loss", 0)
+                    std_val = summary_data.get("std_val_loss", 0)
+                    st.metric("Avg Val Loss", f"{avg_val:.4f} ± {std_val:.4f}")
             with col4:
                 best_fold = summary_data.get("best_fold", 0)
-                best_val_loss = summary_data.get("best_val_loss", 0)
-                st.metric(f"⭐ Best Fold", f"Fold {best_fold + 1} ({best_val_loss:.4f})")
+                best_metric = summary_data.get("best_reward", summary_data.get("best_val_loss", 0))
+                label = "Best Reward" if is_grpo else "Best Val"
+                st.metric(f"⭐ Best Fold", f"Fold {best_fold + 1} ({label}: {best_metric:.4f})")
         
         # Fold-by-Fold Comparison Chart
         if kfold_summary and "fold_results" in kfold_summary:
@@ -3012,41 +3212,59 @@ def render_training_metrics_panel():
                 # Create comparison dataframe
                 fold_data = []
                 for result in fold_results:
-                    fold_data.append({
-                        "Fold": f"Fold {result['fold'] + 1}",
-                        "Final Loss": result.get("final_loss", 0),
-                        "Val Loss": result.get("best_val_loss", 0),
-                        "Train Samples": result.get("train_samples", 0),
-                        "Val Samples": result.get("val_samples", 0),
-                        "Training Time (s)": result.get("total_time", 0),
-                    })
+                    if is_grpo:
+                        fold_data.append({
+                            "Fold": f"Fold {result['fold'] + 1}",
+                            "Best Reward": result.get("best_eval_reward", 0),
+                            "Final Loss": result.get("final_total_loss", 0),
+                            "Train Samples": result.get("train_samples", 0),
+                            "Val Samples": result.get("val_samples", 0),
+                            "Training Time (s)": result.get("total_time", 0),
+                        })
+                    else:
+                        fold_data.append({
+                            "Fold": f"Fold {result['fold'] + 1}",
+                            "Final Loss": result.get("final_loss", 0),
+                            "Val Loss": result.get("best_val_loss", 0),
+                            "Train Samples": result.get("train_samples", 0),
+                            "Val Samples": result.get("val_samples", 0),
+                            "Training Time (s)": result.get("total_time", 0),
+                        })
                 
                 df_folds = pd.DataFrame(fold_data)
                 
                 # Display bar chart comparing folds
                 col1, col2 = st.columns(2)
                 with col1:
-                    st.markdown("**Final Loss by Fold**")
-                    st.bar_chart(df_folds.set_index("Fold")["Final Loss"])
+                    metric_name = "Best Reward" if is_grpo else "Final Loss"
+                    st.markdown(f"**{metric_name} by Fold**")
+                    st.bar_chart(df_folds.set_index("Fold")[metric_name])
                 with col2:
-                    st.markdown("**Validation Loss by Fold**")
-                    st.bar_chart(df_folds.set_index("Fold")["Val Loss"])
+                    secondary_metric = "Final Loss" if is_grpo else "Val Loss"
+                    st.markdown(f"**{secondary_metric} by Fold**")
+                    st.bar_chart(df_folds.set_index("Fold")[secondary_metric])
                 
                 # Detailed table
                 st.markdown("**Detailed Fold Results**")
                 df_display = df_folds.copy()
                 df_display["Final Loss"] = df_display["Final Loss"].apply(lambda x: f"{x:.4f}")
-                df_display["Val Loss"] = df_display["Val Loss"].apply(lambda x: f"{x:.4f}")
+                if "Val Loss" in df_display.columns:
+                    df_display["Val Loss"] = df_display["Val Loss"].apply(lambda x: f"{x:.4f}")
+                if "Best Reward" in df_display.columns:
+                    df_display["Best Reward"] = df_display["Best Reward"].apply(lambda x: f"{x:.4f}")
                 df_display["Training Time (s)"] = df_display["Training Time (s)"].apply(lambda x: f"{x:.1f}")
                 st.dataframe(df_display, width="stretch", hide_index=True)
                 
                 # Best fold recommendation
                 best_fold_idx = kfold_summary.get("best_fold", 0)
+                best_value = kfold_summary.get("best_reward", kfold_summary.get("best_val_loss", 0))
+                descriptor = "highest reward" if is_grpo else "lowest validation loss"
+                target_checkpoint = "best" if not is_grpo else "final"
                 st.success(f"""
                 ⭐ **Recommended:** Use **Fold {best_fold_idx + 1}** adapters for deployment 
-                (lowest validation loss: {kfold_summary.get('best_val_loss', 0):.4f})
+                ({descriptor}: {best_value:.4f})
                 
-                📁 Checkpoint location: `outputs/fold_{best_fold_idx}/checkpoints/best/`
+                📁 Checkpoint location: `outputs/fold_{best_fold_idx}/checkpoints/{target_checkpoint}/`
                 """)
         
         # Total training time for k-fold

--- a/app.py
+++ b/app.py
@@ -1566,6 +1566,7 @@ def page_data_preparation():
                                     chunk_size=chunk_size,
                                     clean_timestamps=clean_timestamps, 
                                     clean_urls=clean_urls,
+                                    clean_speaker_labels=clean_speakers,
                                     model=st.session_state.get('openrouter_model'),
                                 )
                             elif use_local_model:
@@ -1574,12 +1575,14 @@ def page_data_preparation():
                                     text, st.session_state.helper_model, st.session_state.helper_tokenizer,
                                     output_format=ai_format, chunk_size=chunk_size,
                                     clean_timestamps=clean_timestamps, clean_urls=clean_urls,
+                                    clean_speaker_labels=clean_speakers,
                                 )
                             else:
                                 examples = preprocess_raw_text(
                                     text, output_format=output_format, chunk_size=chunk_size,
                                     chunk_overlap=chunk_overlap, clean_timestamps=clean_timestamps,
-                                    clean_urls=clean_urls, topic=topic,
+                                    clean_urls=clean_urls, clean_speaker_labels=clean_speakers,
+                                    topic=topic,
                                 )
                             all_examples.extend(examples)
                     else:
@@ -1598,6 +1601,7 @@ def page_data_preparation():
                                 chunk_size=chunk_size,
                                 clean_timestamps=clean_timestamps, 
                                 clean_urls=clean_urls,
+                                clean_speaker_labels=clean_speakers,
                                 model=st.session_state.get('openrouter_model'),
                                 progress_callback=progress_cb,
                             )
@@ -1607,13 +1611,15 @@ def page_data_preparation():
                                 raw_text, st.session_state.helper_model, st.session_state.helper_tokenizer,
                                 output_format=ai_format, chunk_size=chunk_size,
                                 clean_timestamps=clean_timestamps, clean_urls=clean_urls,
+                                clean_speaker_labels=clean_speakers,
                                 progress_callback=progress_cb,
                             )
                         else:
                             all_examples = preprocess_raw_text(
                                 raw_text, output_format=output_format, chunk_size=chunk_size,
                                 chunk_overlap=chunk_overlap, clean_timestamps=clean_timestamps,
-                                clean_urls=clean_urls, topic=topic,
+                                clean_urls=clean_urls, clean_speaker_labels=clean_speakers,
+                                topic=topic,
                             )
                     
                     if not all_examples:

--- a/configs/current.yaml
+++ b/configs/current.yaml
@@ -28,9 +28,37 @@ training:
   save_total_limit: 3
   logging_steps: 10
   eval_steps: 100
+grpo:
+  group_size: 4
+  clip_epsilon: 0.2
+  beta_kl: 0.02
+  advantage_epsilon: 1.0e-08
+  max_generation_tokens: 128
+  temperature: 0.8
+  top_p: 1.0
+  warmup_epochs: 1
+  preflight_sample_size: 128
+  min_reward_std: 1.0e-06
+  eval_steps: 50
+  logging_steps: 10
+reward:
+  function: weighted_rules
+  weights:
+    exact_match: 0.4
+    keyword_coverage: 0.3
+    json_format: 0.2
+    length_band: 0.1
+  pass_threshold: 0.6
+  metadata_keyword_field: keywords
+  min_response_length: 16
+  max_response_length: 512
+  require_nonzero_variance: true
 data:
   train_file: data/processed/train.jsonl
   valid_file: data/processed/valid.jsonl
+  rl_train_file: data/processed/rl_train.jsonl
+  rl_valid_file: data/processed/rl_valid.jsonl
+  rl_eval_file: data/processed/rl_eval.jsonl
   prompt_template: '<|begin_of_text|><|start_header_id|>user<|end_header_id|>
 
     {instruction}<|eot_id|><|start_header_id|>assistant<|end_header_id|>

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -75,9 +75,10 @@ data:
   rl_valid_file: "data/processed/rl_valid.jsonl"
   rl_eval_file: "data/processed/rl_eval.jsonl"
   prompt_template: |
-    <|begin_of_text|><|start_header_id|>user<|end_header_id|>
-    {instruction}<|eot_id|><|start_header_id|>assistant<|end_header_id|>
-    {response}<|eot_id|>
+    <|im_start|>user
+    {instruction}<|im_end|>
+    <|im_start|>assistant
+    {response}<|im_end|>
   training_method: "basic"
   kfold_splits: 5
   kfold_seed: 42

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -38,14 +38,49 @@ training:
   logging_steps: 10
   eval_steps: 100
 
+# GRPO configuration
+grpo:
+  group_size: 4
+  clip_epsilon: 0.2
+  beta_kl: 0.02
+  advantage_epsilon: 1.0e-8
+  max_generation_tokens: 128
+  temperature: 0.8
+  top_p: 1.0
+  warmup_epochs: 1
+  preflight_sample_size: 128
+  min_reward_std: 1.0e-6
+  eval_steps: 50
+  logging_steps: 10
+
+# Reward function configuration for GRPO
+reward:
+  function: "weighted_rules"
+  weights:
+    exact_match: 0.4
+    keyword_coverage: 0.3
+    json_format: 0.2
+    length_band: 0.1
+  pass_threshold: 0.6
+  metadata_keyword_field: "keywords"
+  min_response_length: 16
+  max_response_length: 512
+  require_nonzero_variance: true
+
 # Data configuration
 data:
   train_file: "data/processed/train.jsonl"
   valid_file: "data/processed/valid.jsonl"
+  rl_train_file: "data/processed/rl_train.jsonl"
+  rl_valid_file: "data/processed/rl_valid.jsonl"
+  rl_eval_file: "data/processed/rl_eval.jsonl"
   prompt_template: |
     <|begin_of_text|><|start_header_id|>user<|end_header_id|>
     {instruction}<|eot_id|><|start_header_id|>assistant<|end_header_id|>
     {response}<|eot_id|>
+  training_method: "basic"
+  kfold_splits: 5
+  kfold_seed: 42
 
 # Output configuration
 output:

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Post-training evaluation for GRPO checkpoints."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any, Dict, List, Mapping, Optional
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import mlx.core as mx
+
+from src.config import Config
+from src.model_utils import apply_lora, load_base_model
+from src.rewards import compute_reward
+from src.rl_data import load_rl_dataset, validate_rl_schema
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Evaluate base/pretrain/grpo models with reward metrics")
+    parser.add_argument("--config", type=str, default="configs/default.yaml", help="Path to config file")
+    parser.add_argument("--eval-file", type=str, default=None, help="Optional override for RL eval file")
+    parser.add_argument("--output-dir", type=str, default="outputs/evals", help="Directory for evaluation artifacts")
+    parser.add_argument("--pretrain-checkpoint", type=str, default="outputs/checkpoints/pretrain", help="Pretrain checkpoint dir")
+    parser.add_argument("--grpo-checkpoint", type=str, default="outputs/checkpoints/final", help="GRPO final checkpoint dir")
+    parser.add_argument("--max-tokens", type=int, default=None, help="Override generation max tokens")
+    return parser.parse_args()
+
+
+def _format_prompt(prompt: str, template: Optional[str]) -> str:
+    if not template:
+        return prompt
+    partial = template
+    if "{response}" in partial:
+        partial = partial.split("{response}")[0]
+    try:
+        return partial.format(instruction=prompt)
+    except Exception:
+        return prompt
+
+
+def _safe_generate(model: Any, tokenizer: Any, prompt: str, max_tokens: int, temperature: float, top_p: float) -> str:
+    from mlx_lm import generate
+
+    kwargs = {
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "verbose": False,
+    }
+    try:
+        return generate(model, tokenizer, temperature=temperature, top_p=top_p, **kwargs)
+    except TypeError:
+        return generate(model, tokenizer, **kwargs)
+
+
+def _load_variant_model(config: Config, checkpoint_dir: Optional[Path]) -> tuple[Any, Any]:
+    model, tokenizer = load_base_model(config.model.name)
+    if checkpoint_dir is None:
+        return model, tokenizer
+
+    adapter_file = checkpoint_dir / "adapters.safetensors"
+    if not adapter_file.exists():
+        raise FileNotFoundError(f"Missing adapters file: {adapter_file}")
+
+    model = apply_lora(
+        model,
+        rank=config.lora.rank,
+        alpha=config.lora.alpha,
+        dropout=0.0,
+        target_modules=config.lora.target_modules,
+    )
+
+    adapters = mx.load(str(adapter_file))
+    model.load_weights(list(adapters.items()), strict=False)
+    return model, tokenizer
+
+
+def evaluate_variant(
+    variant_name: str,
+    config: Config,
+    dataset: List[Dict[str, Any]],
+    reward_config: Mapping[str, Any],
+    checkpoint_dir: Optional[Path],
+    max_tokens: int,
+) -> Dict[str, Any]:
+    model, tokenizer = _load_variant_model(config, checkpoint_dir)
+
+    scores: List[float] = []
+    component_values: Dict[str, List[float]] = {}
+    empty_responses = 0
+    json_failures = 0
+    samples: List[Dict[str, Any]] = []
+
+    for sample in dataset:
+        prompt = sample["prompt"]
+        prompt_text = _format_prompt(prompt, config.data.prompt_template)
+        response = _safe_generate(
+            model,
+            tokenizer,
+            prompt_text,
+            max_tokens=max_tokens,
+            temperature=config.grpo.temperature,
+            top_p=config.grpo.top_p,
+        )
+
+        reward = compute_reward(sample, response, reward_config)
+        scores.append(reward.total_score)
+
+        if not response.strip():
+            empty_responses += 1
+
+        json_component = reward.components.get("json_format")
+        if json_component is not None and json_component < 1.0:
+            json_failures += 1
+
+        for name, value in reward.components.items():
+            component_values.setdefault(name, []).append(float(value))
+
+        samples.append(
+            {
+                "variant": variant_name,
+                "prompt": prompt,
+                "reference": sample.get("reference", ""),
+                "response": response,
+                "reward": reward.total_score,
+                "reward_components": reward.components,
+                "passed": reward.passed,
+            }
+        )
+
+    avg = sum(scores) / len(scores) if scores else 0.0
+    std = (sum((s - avg) ** 2 for s in scores) / len(scores)) ** 0.5 if scores else 0.0
+
+    component_means = {
+        name: (sum(values) / len(values) if values else 0.0)
+        for name, values in component_values.items()
+    }
+
+    return {
+        "variant": variant_name,
+        "num_samples": len(dataset),
+        "avg_reward": avg,
+        "std_reward": std,
+        "pass_rate": (sum(1 for s in scores if s >= reward_config.get("pass_threshold", 0.6)) / len(scores)) if scores else 0.0,
+        "empty_response_rate": (empty_responses / len(dataset)) if dataset else 0.0,
+        "json_error_rate": (json_failures / len(dataset)) if dataset else 0.0,
+        "component_means": component_means,
+        "samples": samples,
+    }
+
+
+def run_evaluation(args: argparse.Namespace) -> Dict[str, Any]:
+    config = Config.from_yaml(args.config)
+    eval_file = Path(args.eval_file) if args.eval_file else Path(config.data.rl_eval_file)
+
+    raw_eval = load_rl_dataset(eval_file)
+    eval_data, schema_report = validate_rl_schema(raw_eval)
+    if not eval_data:
+        raise ValueError("Evaluation dataset contains no valid prompt/reference samples")
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    reward_config = config.reward.to_dict()
+    max_tokens = args.max_tokens or config.grpo.max_generation_tokens
+
+    base_result = evaluate_variant(
+        "base",
+        config,
+        eval_data,
+        reward_config,
+        checkpoint_dir=None,
+        max_tokens=max_tokens,
+    )
+
+    pretrain_cp = Path(args.pretrain_checkpoint)
+    pretrain_result = None
+    if pretrain_cp.exists():
+        pretrain_result = evaluate_variant(
+            "pretrain",
+            config,
+            eval_data,
+            reward_config,
+            checkpoint_dir=pretrain_cp,
+            max_tokens=max_tokens,
+        )
+
+    grpo_cp = Path(args.grpo_checkpoint)
+    grpo_result = None
+    if grpo_cp.exists():
+        grpo_result = evaluate_variant(
+            "grpo_final",
+            config,
+            eval_data,
+            reward_config,
+            checkpoint_dir=grpo_cp,
+            max_tokens=max_tokens,
+        )
+
+    all_variants = [r for r in [base_result, pretrain_result, grpo_result] if r is not None]
+
+    def _win_rate(target: Dict[str, Any], baseline: Dict[str, Any]) -> float:
+        t = [s["reward"] for s in target["samples"]]
+        b = [s["reward"] for s in baseline["samples"]]
+        if not t or not b:
+            return 0.0
+        wins = sum(1 for x, y in zip(t, b) if x > y)
+        return wins / min(len(t), len(b))
+
+    summary = {
+        "schema": schema_report.to_dict(),
+        "variants": [
+            {k: v for k, v in variant.items() if k != "samples"}
+            for variant in all_variants
+        ],
+    }
+
+    if grpo_result is not None:
+        summary["grpo_vs_base_win_rate"] = _win_rate(grpo_result, base_result)
+        if pretrain_result is not None:
+            summary["grpo_vs_pretrain_win_rate"] = _win_rate(grpo_result, pretrain_result)
+
+    summary_path = output_dir / "grpo_eval_summary.json"
+    samples_path = output_dir / "grpo_eval_samples.jsonl"
+
+    with open(summary_path, "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+
+    with open(samples_path, "w", encoding="utf-8") as f:
+        for variant in all_variants:
+            for sample in variant["samples"]:
+                f.write(json.dumps(sample, ensure_ascii=False) + "\n")
+
+    print(f"Evaluation summary saved to: {summary_path}")
+    print(f"Evaluation samples saved to: {samples_path}")
+
+    return summary
+
+
+def main() -> None:
+    args = parse_args()
+    run_evaluation(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -14,17 +14,22 @@ from pathlib import Path
 # Add parent directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from src.data_utils import convert_to_mlx_format, load_dataset, save_jsonl
+from src.data_utils import convert_to_mlx_format
+from src.rl_data import convert_to_grpo_format
 
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Prepare data for MLX LoRA training")
+    parser.add_argument("--mode", type=str, default="sft", choices=["sft", "grpo"],
+                        help="Preparation mode: sft (instruction-response) or grpo (prompt-reference)")
     parser.add_argument("--input", type=str, required=True,
                         help="Path to input dataset (json or jsonl)")
     parser.add_argument("--output", type=str, default="data/processed",
                         help="Output directory for processed files")
     parser.add_argument("--val-split", type=float, default=0.1,
                         help="Validation split ratio (default: 0.1)")
+    parser.add_argument("--eval-split", type=float, default=0.1,
+                        help="Evaluation split ratio used only in grpo mode (default: 0.1)")
     parser.add_argument("--instruction-key", type=str, default="instruction",
                         help="Key for instruction/input field")
     parser.add_argument("--response-key", type=str, default="response",
@@ -40,25 +45,42 @@ def main():
     print("=" * 60)
     print("Data Preparation for MLX LoRA Training")
     print("=" * 60)
+    print(f"Mode: {args.mode}")
     print(f"Input: {args.input}")
     print(f"Output: {args.output}")
     print(f"Validation split: {args.val_split * 100:.0f}%")
+    if args.mode == "grpo":
+        print(f"Eval split: {args.eval_split * 100:.0f}%")
     print("=" * 60)
     
-    # Convert data
-    train_path, val_path = convert_to_mlx_format(
-        input_path=args.input,
-        output_dir=args.output,
-        val_ratio=args.val_split,
-        instruction_key=args.instruction_key,
-        response_key=args.response_key,
-        template=args.template,
-    )
+    if args.mode == "grpo":
+        train_path, val_path, eval_path = convert_to_grpo_format(
+            input_path=args.input,
+            output_dir=args.output,
+            val_ratio=args.val_split,
+            eval_ratio=args.eval_split,
+            instruction_key=args.instruction_key,
+            response_key=args.response_key,
+        )
+    else:
+        train_path, val_path = convert_to_mlx_format(
+            input_path=args.input,
+            output_dir=args.output,
+            val_ratio=args.val_split,
+            instruction_key=args.instruction_key,
+            response_key=args.response_key,
+            template=args.template,
+        )
     
     print("\n" + "=" * 60)
     print("Data preparation complete!")
-    print(f"Training file: {train_path}")
-    print(f"Validation file: {val_path}")
+    if args.mode == "grpo":
+        print(f"RL train file: {train_path}")
+        print(f"RL validation file: {val_path}")
+        print(f"RL eval file: {eval_path}")
+    else:
+        print(f"Training file: {train_path}")
+        print(f"Validation file: {val_path}")
     print("=" * 60)
 
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,43 +1,52 @@
 #!/usr/bin/env python3
-"""
-Training script for MLX LoRA fine-tuning.
+"""Training script for MLX LoRA fine-tuning and GRPO."""
 
-Usage:
-    python scripts/train.py --config configs/default.yaml
-    python scripts/train.py --model meta-llama/Llama-3.2-1B --data data/processed
-"""
+from __future__ import annotations
 
 import argparse
-import sys
+import json
 from pathlib import Path
+import subprocess
+import sys
+from typing import Any, Dict, List, Optional
 
 # Add parent directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+import mlx.core as mx
+
 from src.config import Config
 from src.data_utils import load_dataset
-from src.model_utils import load_base_model, apply_lora, save_adapters
-from src.trainer import LoRATrainer, KFoldTrainer
+from src.grpo_trainer import GRPOKFoldTrainer, GRPOTrainer
+from src.model_utils import apply_lora, load_base_model, save_adapters
+from src.rl_data import load_rl_dataset, run_grpo_preflight, save_preflight_report
+from src.trainer import KFoldTrainer, LoRATrainer
 
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="Train a LoRA adapter with MLX")
-    parser.add_argument("--config", type=str, default="configs/default.yaml",
-                        help="Path to config file")
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train LoRA adapters with MLX (SFT/KFold/GRPO)")
+    parser.add_argument("--config", type=str, default="configs/default.yaml", help="Path to config file")
     parser.add_argument("--model", type=str, help="Override model name")
-    parser.add_argument("--data", type=str, help="Override data directory")
+    parser.add_argument("--data", type=str, help="Override SFT data directory")
     parser.add_argument("--output", type=str, help="Override output directory")
     parser.add_argument("--epochs", type=int, help="Override number of epochs")
     parser.add_argument("--batch-size", type=int, help="Override batch size")
     parser.add_argument("--lr", type=float, help="Override learning rate")
     parser.add_argument("--lora-rank", type=int, help="Override LoRA rank")
+    parser.add_argument(
+        "--training-method",
+        type=str,
+        choices=["basic", "kfold", "grpo", "grpo_kfold"],
+        help="Override training method",
+    )
     return parser.parse_args()
 
 
-def create_model_loader(config):
+def create_model_loader(config: Config):
     """Create a function that loads a fresh model with LoRA applied."""
+
     def load_model():
-        model, tokenizer = load_base_model(config.model.name)
+        model, _ = load_base_model(config.model.name)
         model = apply_lora(
             model,
             rank=config.lora.rank,
@@ -46,84 +55,82 @@ def create_model_loader(config):
             target_modules=config.lora.target_modules,
         )
         return model
+
     return load_model
 
 
-def main():
-    args = parse_args()
-    
-    # Load configuration
-    config = Config.from_yaml(args.config)
-    
-    # Apply CLI overrides
-    if args.model:
-        config.model.name = args.model
-    if args.data:
-        config.data.train_file = f"{args.data}/train.jsonl"
-        config.data.valid_file = f"{args.data}/valid.jsonl"
-    if args.output:
-        config.output.dir = args.output
-        config.output.adapters_dir = f"{args.output}/adapters"
-        config.output.checkpoints_dir = f"{args.output}/checkpoints"
-    if args.epochs:
-        config.training.num_epochs = args.epochs
-    if args.batch_size:
-        config.training.batch_size = args.batch_size
-    if args.lr:
-        config.training.learning_rate = args.lr
-    if args.lora_rank:
-        config.lora.rank = args.lora_rank
-    
-    # Check training method
-    training_method = getattr(config.data, 'training_method', 'basic')
-    kfold_splits = getattr(config.data, 'kfold_splits', 5)
-    kfold_seed = getattr(config.data, 'kfold_seed', 42)
-    
-    print("=" * 60)
-    print("MLX LoRA Fine-tuning")
-    print("=" * 60)
-    print(f"Model: {config.model.name}")
-    print(f"LoRA rank: {config.lora.rank}, alpha: {config.lora.alpha}")
-    print(f"Batch size: {config.training.batch_size}")
-    print(f"Learning rate: {config.training.learning_rate}")
-    print(f"Epochs: {config.training.num_epochs}")
-    print(f"Training method: {training_method.upper()}" + (f" ({kfold_splits} folds)" if training_method == "kfold" else ""))
-    print("=" * 60)
-    
-    # Ensure output directories exist
-    config.output.ensure_dirs()
-    
-    # Load training data
+def _to_sft_examples(samples: List[Dict[str, Any]], template: Optional[str]) -> List[Dict[str, str]]:
+    examples: List[Dict[str, str]] = []
+    for item in samples:
+        prompt = str(item.get("prompt", "")).strip()
+        reference = str(item.get("reference", "")).strip()
+        if not prompt or not reference:
+            continue
+        if template:
+            try:
+                text = template.format(instruction=prompt, response=reference)
+            except Exception:
+                text = f"### Instruction:\n{prompt}\n\n### Response:\n{reference}"
+        else:
+            text = f"### Instruction:\n{prompt}\n\n### Response:\n{reference}"
+        examples.append({"text": text})
+    return examples
+
+
+def _run_post_eval(
+    config_path: str,
+    eval_file: str,
+    pretrain_checkpoint: Path,
+    grpo_checkpoint: Path,
+    output_dir: Path,
+) -> None:
+    """Run post-training GRPO evaluation script."""
+    cmd = [
+        sys.executable,
+        "scripts/evaluate.py",
+        "--config",
+        config_path,
+        "--eval-file",
+        eval_file,
+        "--output-dir",
+        str(output_dir),
+        "--pretrain-checkpoint",
+        str(pretrain_checkpoint),
+        "--grpo-checkpoint",
+        str(grpo_checkpoint),
+    ]
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as exc:
+        print(f"Warning: post-training evaluation failed ({exc})")
+
+
+def run_basic_or_kfold(config: Config, training_method: str) -> Dict[str, Any]:
+    """Run original SFT basic/kfold training methods."""
     print("\nLoading training data...")
     train_data = load_dataset(config.data.train_file)
     print(f"Loaded {len(train_data)} training examples")
-    
-    # Check if using K-Fold
+
     if training_method == "kfold":
-        print(f"\n🔄 Using K-Fold Cross-Validation with {kfold_splits} folds")
-        print("=" * 60)
-        
-        # Load model and tokenizer once to get tokenizer
+        print(f"\n🔄 Using K-Fold Cross-Validation with {config.data.kfold_splits} folds")
+
         print("\nLoading tokenizer...")
         _, tokenizer = load_base_model(config.model.name)
-        
-        # Create model loader function for K-Fold trainer
+
         model_loader = create_model_loader(config)
-        
-        # Combine train and validation data for k-fold (it will split internally)
+
         full_data = train_data
         if Path(config.data.valid_file).exists():
             val_data = load_dataset(config.data.valid_file)
             full_data = train_data + val_data
             print(f"Combined train + val data: {len(full_data)} total examples")
-        
-        # Create K-Fold trainer
+
         trainer = KFoldTrainer(
             model_loader=model_loader,
             tokenizer=tokenizer,
             full_data=full_data,
-            k=kfold_splits,
-            seed=kfold_seed,
+            k=config.data.kfold_splits,
+            seed=config.data.kfold_seed,
             learning_rate=config.training.learning_rate,
             batch_size=config.training.batch_size,
             num_epochs=config.training.num_epochs,
@@ -141,72 +148,293 @@ def main():
                 "dropout": config.lora.dropout,
             },
         )
-        
-        # Train with K-Fold
-        print("\nStarting K-Fold training...")
-        stats = trainer.train()
-        
-        print("\n" + "=" * 60)
-        print("K-Fold Training complete!")
-        print(f"Total folds: {stats['k']}")
-        print(f"Total time: {stats['total_time']:.2f}s")
-        print(f"Average final loss: {stats['avg_final_loss']:.4f} ± {stats['std_final_loss']:.4f}")
-        print(f"Average val loss: {stats['avg_val_loss']:.4f} ± {stats['std_val_loss']:.4f}")
-        print(f"Best fold: {stats['best_fold'] + 1} (val loss: {stats['best_val_loss']:.4f})")
-        print(f"Best model saved to: {config.output.dir}/fold_{stats['best_fold']}/checkpoints/best")
-        print("=" * 60)
-        
-    else:
-        # Standard basic training
-        print("\nLoading model...")
-        model, tokenizer = load_base_model(config.model.name)
-        
-        # Apply LoRA
-        print("\nApplying LoRA adapters...")
-        model = apply_lora(
-            model,
-            rank=config.lora.rank,
-            alpha=config.lora.alpha,
-            dropout=config.lora.dropout,
-            target_modules=config.lora.target_modules,
-        )
-        
-        val_data = None
-        if Path(config.data.valid_file).exists():
-            val_data = load_dataset(config.data.valid_file)
-            print(f"Loaded {len(val_data)} validation examples")
-        
-        # Create trainer
-        trainer = LoRATrainer(
+        return trainer.train()
+
+    print("\nLoading model...")
+    model, tokenizer = load_base_model(config.model.name)
+    print("\nApplying LoRA adapters...")
+    model = apply_lora(
+        model,
+        rank=config.lora.rank,
+        alpha=config.lora.alpha,
+        dropout=config.lora.dropout,
+        target_modules=config.lora.target_modules,
+    )
+
+    val_data = None
+    if Path(config.data.valid_file).exists():
+        val_data = load_dataset(config.data.valid_file)
+        print(f"Loaded {len(val_data)} validation examples")
+
+    trainer = LoRATrainer(
+        model=model,
+        tokenizer=tokenizer,
+        train_data=train_data,
+        val_data=val_data,
+        learning_rate=config.training.learning_rate,
+        batch_size=config.training.batch_size,
+        num_epochs=config.training.num_epochs,
+        warmup_steps=config.training.warmup_steps,
+        weight_decay=config.training.weight_decay,
+        max_seq_length=config.model.max_seq_length,
+        gradient_accumulation_steps=config.training.gradient_accumulation_steps,
+        save_steps=config.training.save_steps,
+        eval_steps=config.training.eval_steps,
+        logging_steps=config.training.logging_steps,
+        output_dir=config.output.dir,
+        model_name=config.model.name,
+        lora_config={
+            "rank": config.lora.rank,
+            "alpha": config.lora.alpha,
+            "dropout": config.lora.dropout,
+        },
+    )
+    return trainer.train()
+
+
+def run_grpo(config: Config, config_path: str) -> Dict[str, Any]:
+    """Run GRPO single-run training with mandatory preflight + warmup + post-eval."""
+    rl_train = load_rl_dataset(config.data.rl_train_file)
+    rl_valid = load_rl_dataset(config.data.rl_valid_file) if Path(config.data.rl_valid_file).exists() else []
+
+    preflight_data, preflight_report = run_grpo_preflight(
+        data=rl_train,
+        reward_config=config.reward.to_dict(),
+        min_prompt_length=3,
+        min_reference_length=1,
+        sample_size=config.grpo.preflight_sample_size,
+        seed=config.data.kfold_seed,
+        require_nonzero_variance=config.reward.require_nonzero_variance,
+        min_reward_std=config.grpo.min_reward_std,
+    )
+    logs_dir = Path(config.output.logs_dir)
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    save_preflight_report(preflight_report, logs_dir / "grpo_preflight.json")
+    print("✅ GRPO preflight passed")
+
+    print("\nLoading model for GRPO...")
+    model, tokenizer = load_base_model(config.model.name)
+    model = apply_lora(
+        model,
+        rank=config.lora.rank,
+        alpha=config.lora.alpha,
+        dropout=config.lora.dropout,
+        target_modules=config.lora.target_modules,
+    )
+
+    # Warmup SFT stage.
+    if config.grpo.warmup_epochs > 0:
+        print(f"\n🔥 Running SFT warmup for {config.grpo.warmup_epochs} epoch(s)")
+        warmup_trainer = LoRATrainer(
             model=model,
             tokenizer=tokenizer,
-            train_data=train_data,
-            val_data=val_data,
+            train_data=_to_sft_examples(preflight_data, config.data.prompt_template),
+            val_data=_to_sft_examples(rl_valid, config.data.prompt_template),
             learning_rate=config.training.learning_rate,
             batch_size=config.training.batch_size,
-            num_epochs=config.training.num_epochs,
-            warmup_steps=config.training.warmup_steps,
-            weight_decay=config.training.weight_decay,
+            num_epochs=config.grpo.warmup_epochs,
+            warmup_steps=0,
+            weight_decay=0.0,
             max_seq_length=config.model.max_seq_length,
-            save_steps=config.training.save_steps,
-            eval_steps=config.training.eval_steps,
-            logging_steps=config.training.logging_steps,
+            gradient_accumulation_steps=config.training.gradient_accumulation_steps,
+            save_steps=10_000_000,
+            eval_steps=10_000_000,
+            logging_steps=10_000_000,
             output_dir=config.output.dir,
+            model_name=config.model.name,
+            lora_config={"rank": config.lora.rank, "alpha": config.lora.alpha, "dropout": config.lora.dropout},
         )
-        
-        # Train
-        print("\nStarting training...")
-        stats = trainer.train()
-        
-        print("\n" + "=" * 60)
-        print("Training complete!")
-        print(f"Total steps: {stats['total_steps']}")
-        print(f"Total time: {stats['total_time']:.2f}s")
-        print(f"Final loss: {stats['final_loss']:.4f}")
-        if stats['best_val_loss']:
-            print(f"Best validation loss: {stats['best_val_loss']:.4f}")
-        print(f"Model saved to: {config.output.checkpoints_dir}/final")
-        print("=" * 60)
+        warmup_trainer.train()
+        warmup_trainer._save_checkpoint("pretrain")
+    else:
+        pretrain_dir = Path(config.output.dir) / "checkpoints" / "pretrain"
+        save_adapters(model, pretrain_dir)
+
+    pretrain_checkpoint = Path(config.output.dir) / "checkpoints" / "pretrain"
+
+    # Build frozen reference policy from warmup checkpoint.
+    reference_model, _ = load_base_model(config.model.name)
+    reference_model = apply_lora(
+        reference_model,
+        rank=config.lora.rank,
+        alpha=config.lora.alpha,
+        dropout=config.lora.dropout,
+        target_modules=config.lora.target_modules,
+    )
+    pretrain_adapters = mx.load(str(pretrain_checkpoint / "adapters.safetensors"))
+    reference_model.load_weights(list(pretrain_adapters.items()), strict=False)
+    model.load_weights(list(pretrain_adapters.items()), strict=False)
+
+    trainer = GRPOTrainer(
+        model=model,
+        reference_model=reference_model,
+        tokenizer=tokenizer,
+        train_data=preflight_data,
+        val_data=rl_valid,
+        reward_config=config.reward.to_dict(),
+        learning_rate=config.training.learning_rate,
+        batch_size=config.training.batch_size,
+        num_epochs=config.training.num_epochs,
+        group_size=config.grpo.group_size,
+        clip_epsilon=config.grpo.clip_epsilon,
+        beta_kl=config.grpo.beta_kl,
+        advantage_epsilon=config.grpo.advantage_epsilon,
+        max_seq_length=config.model.max_seq_length,
+        max_generation_tokens=config.grpo.max_generation_tokens,
+        temperature=config.grpo.temperature,
+        top_p=config.grpo.top_p,
+        save_steps=config.training.save_steps,
+        eval_steps=config.grpo.eval_steps,
+        logging_steps=config.grpo.logging_steps,
+        output_dir=config.output.dir,
+        prompt_template=config.data.prompt_template,
+        model_name=config.model.name,
+        lora_config={"rank": config.lora.rank, "alpha": config.lora.alpha, "dropout": config.lora.dropout},
+    )
+
+    stats = trainer.train()
+
+    eval_file = config.data.rl_eval_file if Path(config.data.rl_eval_file).exists() else config.data.rl_train_file
+    _run_post_eval(
+        config_path=config_path,
+        eval_file=eval_file,
+        pretrain_checkpoint=pretrain_checkpoint,
+        grpo_checkpoint=Path(config.output.dir) / "checkpoints" / "final",
+        output_dir=Path(config.output.dir) / "evals",
+    )
+    return stats
+
+
+def run_grpo_kfold(config: Config, config_path: str) -> Dict[str, Any]:
+    """Run GRPO K-Fold training with warmup per fold and automatic post-eval."""
+    rl_train = load_rl_dataset(config.data.rl_train_file)
+    rl_valid = load_rl_dataset(config.data.rl_valid_file) if Path(config.data.rl_valid_file).exists() else []
+    full_data = rl_train + rl_valid
+
+    normalized_data, preflight_report = run_grpo_preflight(
+        data=full_data,
+        reward_config=config.reward.to_dict(),
+        min_prompt_length=3,
+        min_reference_length=1,
+        sample_size=config.grpo.preflight_sample_size,
+        seed=config.data.kfold_seed,
+        require_nonzero_variance=config.reward.require_nonzero_variance,
+        min_reward_std=config.grpo.min_reward_std,
+    )
+    logs_dir = Path(config.output.logs_dir)
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    save_preflight_report(preflight_report, logs_dir / "grpo_kfold_preflight.json")
+    print("✅ GRPO K-Fold preflight passed")
+
+    # Load tokenizer once.
+    _, tokenizer = load_base_model(config.model.name)
+
+    model_loader = create_model_loader(config)
+    reference_model_loader = create_model_loader(config)
+
+    trainer = GRPOKFoldTrainer(
+        model_loader=model_loader,
+        reference_model_loader=reference_model_loader,
+        tokenizer=tokenizer,
+        full_data=normalized_data,
+        reward_config=config.reward.to_dict(),
+        k=config.data.kfold_splits,
+        seed=config.data.kfold_seed,
+        learning_rate=config.training.learning_rate,
+        batch_size=config.training.batch_size,
+        num_epochs=config.training.num_epochs,
+        group_size=config.grpo.group_size,
+        clip_epsilon=config.grpo.clip_epsilon,
+        beta_kl=config.grpo.beta_kl,
+        advantage_epsilon=config.grpo.advantage_epsilon,
+        max_seq_length=config.model.max_seq_length,
+        max_generation_tokens=config.grpo.max_generation_tokens,
+        temperature=config.grpo.temperature,
+        top_p=config.grpo.top_p,
+        save_steps=config.training.save_steps,
+        eval_steps=config.grpo.eval_steps,
+        logging_steps=config.grpo.logging_steps,
+        output_dir=config.output.dir,
+        prompt_template=config.data.prompt_template,
+        model_name=config.model.name,
+        lora_config={"rank": config.lora.rank, "alpha": config.lora.alpha, "dropout": config.lora.dropout},
+        warmup_epochs=config.grpo.warmup_epochs,
+        warmup_learning_rate=config.training.learning_rate,
+    )
+
+    summary = trainer.train()
+
+    best_fold = summary["best_fold"]
+    fold_dir = Path(config.output.dir) / f"fold_{best_fold}" / "checkpoints"
+    eval_file = config.data.rl_eval_file if Path(config.data.rl_eval_file).exists() else config.data.rl_train_file
+
+    _run_post_eval(
+        config_path=config_path,
+        eval_file=eval_file,
+        pretrain_checkpoint=fold_dir / "pretrain",
+        grpo_checkpoint=fold_dir / "final",
+        output_dir=Path(config.output.dir) / "evals",
+    )
+    return summary
+
+
+def main() -> None:
+    args = parse_args()
+
+    config = Config.from_yaml(args.config)
+
+    if args.model:
+        config.model.name = args.model
+    if args.data:
+        config.data.train_file = f"{args.data}/train.jsonl"
+        config.data.valid_file = f"{args.data}/valid.jsonl"
+        config.data.rl_train_file = f"{args.data}/rl_train.jsonl"
+        config.data.rl_valid_file = f"{args.data}/rl_valid.jsonl"
+        config.data.rl_eval_file = f"{args.data}/rl_eval.jsonl"
+    if args.output:
+        config.output.dir = args.output
+        config.output.adapters_dir = f"{args.output}/adapters"
+        config.output.checkpoints_dir = f"{args.output}/checkpoints"
+        config.output.logs_dir = f"{args.output}/logs"
+    if args.epochs:
+        config.training.num_epochs = args.epochs
+    if args.batch_size:
+        config.training.batch_size = args.batch_size
+    if args.lr:
+        config.training.learning_rate = args.lr
+    if args.lora_rank:
+        config.lora.rank = args.lora_rank
+    if args.training_method:
+        config.data.training_method = args.training_method
+
+    training_method = getattr(config.data, "training_method", "basic")
+
+    print("=" * 70)
+    print("MLX LoRA + GRPO Training")
+    print("=" * 70)
+    print(f"Model: {config.model.name}")
+    print(f"LoRA rank: {config.lora.rank}, alpha: {config.lora.alpha}")
+    print(f"Batch size: {config.training.batch_size}")
+    print(f"Learning rate: {config.training.learning_rate}")
+    print(f"Epochs: {config.training.num_epochs}")
+    print(f"Training method: {training_method}")
+    print("=" * 70)
+
+    config.output.ensure_dirs()
+
+    if training_method in {"basic", "kfold"}:
+        stats = run_basic_or_kfold(config, training_method)
+    elif training_method == "grpo":
+        stats = run_grpo(config, args.config)
+    elif training_method == "grpo_kfold":
+        stats = run_grpo_kfold(config, args.config)
+    else:
+        raise ValueError(f"Unknown training method: {training_method}")
+
+    print("\n" + "=" * 70)
+    print("Training complete")
+    print(json.dumps(stats, indent=2))
+    print("=" * 70)
 
 
 if __name__ == "__main__":

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -23,6 +23,17 @@ from src.rl_data import load_rl_dataset, run_grpo_preflight, save_preflight_repo
 from src.trainer import KFoldTrainer, LoRATrainer
 
 
+def _positive_int(value: str) -> int:
+    """Parse a positive integer for CLI sample limits."""
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"{value!r} is not an integer") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be >= 1")
+    return parsed
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Train LoRA adapters with MLX (SFT/KFold/GRPO)")
     parser.add_argument("--config", type=str, default="configs/default.yaml", help="Path to config file")
@@ -39,7 +50,136 @@ def parse_args() -> argparse.Namespace:
         choices=["basic", "kfold", "grpo", "grpo_kfold"],
         help="Override training method",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate the resolved plan and dataset counts without loading the model or training",
+    )
+    parser.add_argument(
+        "--max-train-samples",
+        type=_positive_int,
+        help="Limit SFT or RL training samples for smoke runs",
+    )
+    parser.add_argument(
+        "--max-val-samples",
+        type=_positive_int,
+        help="Limit SFT or RL validation samples for smoke runs",
+    )
     return parser.parse_args()
+
+
+def _limit_samples(samples: List[Dict[str, Any]], max_samples: Optional[int], label: str) -> List[Dict[str, Any]]:
+    """Return a deterministic prefix of samples when a smoke-test limit is set."""
+    if max_samples is None:
+        return samples
+
+    limited = samples[:max_samples]
+    print(f"Using {len(limited)}/{len(samples)} {label} samples")
+    return limited
+
+
+def _dataset_plan(path: str, loaded_count: int, used_count: int, exists: bool = True) -> Dict[str, Any]:
+    return {
+        "path": path,
+        "exists": exists,
+        "loaded_samples": loaded_count,
+        "used_samples": used_count,
+    }
+
+
+def run_dry_run(
+    config: Config,
+    training_method: str,
+    *,
+    max_train_samples: Optional[int] = None,
+    max_val_samples: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Build a no-training execution plan from config and available data."""
+    plan: Dict[str, Any] = {
+        "dry_run": True,
+        "model": config.model.name,
+        "training_method": training_method,
+        "batch_size": config.training.batch_size,
+        "epochs": config.training.num_epochs,
+        "output_dir": config.output.dir,
+        "sample_limits": {
+            "max_train_samples": max_train_samples,
+            "max_val_samples": max_val_samples,
+        },
+        "datasets": {},
+    }
+
+    if training_method in {"basic", "kfold"}:
+        train_data = load_dataset(config.data.train_file)
+        train_used = _limit_samples(train_data, max_train_samples, "training")
+        plan["datasets"]["train"] = _dataset_plan(
+            config.data.train_file,
+            loaded_count=len(train_data),
+            used_count=len(train_used),
+        )
+
+        valid_file = Path(config.data.valid_file)
+        valid_used: List[Dict[str, Any]] = []
+        if valid_file.exists():
+            valid_data = load_dataset(valid_file)
+            valid_used = _limit_samples(valid_data, max_val_samples, "validation")
+            plan["datasets"]["valid"] = _dataset_plan(
+                config.data.valid_file,
+                loaded_count=len(valid_data),
+                used_count=len(valid_used),
+            )
+        else:
+            plan["datasets"]["valid"] = _dataset_plan(config.data.valid_file, 0, 0, exists=False)
+
+        if training_method == "kfold" and len(train_used) + len(valid_used) < config.data.kfold_splits:
+            raise ValueError(
+                f"K-Fold dry run needs at least {config.data.kfold_splits} samples after limits"
+            )
+
+        return plan
+
+    if training_method in {"grpo", "grpo_kfold"}:
+        rl_train = load_rl_dataset(config.data.rl_train_file)
+        rl_train_used = _limit_samples(rl_train, max_train_samples, "RL training")
+        plan["datasets"]["rl_train"] = _dataset_plan(
+            config.data.rl_train_file,
+            loaded_count=len(rl_train),
+            used_count=len(rl_train_used),
+        )
+
+        rl_valid_file = Path(config.data.rl_valid_file)
+        rl_valid_used: List[Dict[str, Any]] = []
+        if rl_valid_file.exists():
+            rl_valid = load_rl_dataset(rl_valid_file)
+            rl_valid_used = _limit_samples(rl_valid, max_val_samples, "RL validation")
+            plan["datasets"]["rl_valid"] = _dataset_plan(
+                config.data.rl_valid_file,
+                loaded_count=len(rl_valid),
+                used_count=len(rl_valid_used),
+            )
+        else:
+            plan["datasets"]["rl_valid"] = _dataset_plan(config.data.rl_valid_file, 0, 0, exists=False)
+
+        preflight_source = rl_train_used if training_method == "grpo" else rl_train_used + rl_valid_used
+        if training_method == "grpo_kfold" and len(preflight_source) < config.data.kfold_splits:
+            raise ValueError(
+                f"GRPO K-Fold dry run needs at least {config.data.kfold_splits} samples after limits"
+            )
+
+        _, preflight_report = run_grpo_preflight(
+            data=preflight_source,
+            reward_config=config.reward.to_dict(),
+            min_prompt_length=3,
+            min_reference_length=1,
+            sample_size=config.grpo.preflight_sample_size,
+            seed=config.data.kfold_seed,
+            require_nonzero_variance=config.reward.require_nonzero_variance,
+            min_reward_std=config.grpo.min_reward_std,
+        )
+        plan["grpo_preflight"] = preflight_report
+        return plan
+
+    raise ValueError(f"Unknown training method: {training_method}")
 
 
 def create_model_loader(config: Config):
@@ -105,10 +245,20 @@ def _run_post_eval(
         print(f"Warning: post-training evaluation failed ({exc})")
 
 
-def run_basic_or_kfold(config: Config, training_method: str) -> Dict[str, Any]:
+def run_basic_or_kfold(
+    config: Config,
+    training_method: str,
+    *,
+    max_train_samples: Optional[int] = None,
+    max_val_samples: Optional[int] = None,
+) -> Dict[str, Any]:
     """Run original SFT basic/kfold training methods."""
     print("\nLoading training data...")
-    train_data = load_dataset(config.data.train_file)
+    train_data = _limit_samples(
+        load_dataset(config.data.train_file),
+        max_train_samples,
+        "training",
+    )
     print(f"Loaded {len(train_data)} training examples")
 
     if training_method == "kfold":
@@ -121,7 +271,11 @@ def run_basic_or_kfold(config: Config, training_method: str) -> Dict[str, Any]:
 
         full_data = train_data
         if Path(config.data.valid_file).exists():
-            val_data = load_dataset(config.data.valid_file)
+            val_data = _limit_samples(
+                load_dataset(config.data.valid_file),
+                max_val_samples,
+                "validation",
+            )
             full_data = train_data + val_data
             print(f"Combined train + val data: {len(full_data)} total examples")
 
@@ -163,7 +317,11 @@ def run_basic_or_kfold(config: Config, training_method: str) -> Dict[str, Any]:
 
     val_data = None
     if Path(config.data.valid_file).exists():
-        val_data = load_dataset(config.data.valid_file)
+        val_data = _limit_samples(
+            load_dataset(config.data.valid_file),
+            max_val_samples,
+            "validation",
+        )
         print(f"Loaded {len(val_data)} validation examples")
 
     trainer = LoRATrainer(
@@ -192,10 +350,28 @@ def run_basic_or_kfold(config: Config, training_method: str) -> Dict[str, Any]:
     return trainer.train()
 
 
-def run_grpo(config: Config, config_path: str) -> Dict[str, Any]:
+def run_grpo(
+    config: Config,
+    config_path: str,
+    *,
+    max_train_samples: Optional[int] = None,
+    max_val_samples: Optional[int] = None,
+) -> Dict[str, Any]:
     """Run GRPO single-run training with mandatory preflight + warmup + post-eval."""
-    rl_train = load_rl_dataset(config.data.rl_train_file)
-    rl_valid = load_rl_dataset(config.data.rl_valid_file) if Path(config.data.rl_valid_file).exists() else []
+    rl_train = _limit_samples(
+        load_rl_dataset(config.data.rl_train_file),
+        max_train_samples,
+        "RL training",
+    )
+    rl_valid = (
+        _limit_samples(
+            load_rl_dataset(config.data.rl_valid_file),
+            max_val_samples,
+            "RL validation",
+        )
+        if Path(config.data.rl_valid_file).exists()
+        else []
+    )
 
     preflight_data, preflight_report = run_grpo_preflight(
         data=rl_train,
@@ -305,10 +481,28 @@ def run_grpo(config: Config, config_path: str) -> Dict[str, Any]:
     return stats
 
 
-def run_grpo_kfold(config: Config, config_path: str) -> Dict[str, Any]:
+def run_grpo_kfold(
+    config: Config,
+    config_path: str,
+    *,
+    max_train_samples: Optional[int] = None,
+    max_val_samples: Optional[int] = None,
+) -> Dict[str, Any]:
     """Run GRPO K-Fold training with warmup per fold and automatic post-eval."""
-    rl_train = load_rl_dataset(config.data.rl_train_file)
-    rl_valid = load_rl_dataset(config.data.rl_valid_file) if Path(config.data.rl_valid_file).exists() else []
+    rl_train = _limit_samples(
+        load_rl_dataset(config.data.rl_train_file),
+        max_train_samples,
+        "RL training",
+    )
+    rl_valid = (
+        _limit_samples(
+            load_rl_dataset(config.data.rl_valid_file),
+            max_val_samples,
+            "RL validation",
+        )
+        if Path(config.data.rl_valid_file).exists()
+        else []
+    )
     full_data = rl_train + rl_valid
 
     normalized_data, preflight_report = run_grpo_preflight(
@@ -420,14 +614,40 @@ def main() -> None:
     print(f"Training method: {training_method}")
     print("=" * 70)
 
+    if args.dry_run:
+        stats = run_dry_run(
+            config,
+            training_method,
+            max_train_samples=args.max_train_samples,
+            max_val_samples=args.max_val_samples,
+        )
+        print(json.dumps(stats, indent=2))
+        print("Dry run complete. No model was loaded and no training was started.")
+        return
+
     config.output.ensure_dirs()
 
     if training_method in {"basic", "kfold"}:
-        stats = run_basic_or_kfold(config, training_method)
+        stats = run_basic_or_kfold(
+            config,
+            training_method,
+            max_train_samples=args.max_train_samples,
+            max_val_samples=args.max_val_samples,
+        )
     elif training_method == "grpo":
-        stats = run_grpo(config, args.config)
+        stats = run_grpo(
+            config,
+            args.config,
+            max_train_samples=args.max_train_samples,
+            max_val_samples=args.max_val_samples,
+        )
     elif training_method == "grpo_kfold":
-        stats = run_grpo_kfold(config, args.config)
+        stats = run_grpo_kfold(
+            config,
+            args.config,
+            max_train_samples=args.max_train_samples,
+            max_val_samples=args.max_val_samples,
+        )
     else:
         raise ValueError(f"Unknown training method: {training_method}")
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,7 +8,15 @@ __version__ = "0.1.0"
 __author__ = "Santos Sanz"
 
 # Core modules (no MLX dependency)
-from .config import LoRAConfig, TrainingConfig, ModelConfig, HuggingFaceConfig, Config
+from .config import (
+    LoRAConfig,
+    TrainingConfig,
+    GRPOConfig,
+    RewardConfig,
+    ModelConfig,
+    HuggingFaceConfig,
+    Config,
+)
 from .data_utils import (
     load_dataset, prepare_training_data, create_train_val_split, 
     save_jsonl, create_kfold_splits, get_kfold_data
@@ -27,6 +35,9 @@ def __getattr__(name):
     elif name == "KFoldTrainer":
         from .trainer import KFoldTrainer
         return KFoldTrainer
+    elif name in ("GRPOTrainer", "GRPOKFoldTrainer"):
+        from .grpo_trainer import GRPOTrainer, GRPOKFoldTrainer
+        return {"GRPOTrainer": GRPOTrainer, "GRPOKFoldTrainer": GRPOKFoldTrainer}[name]
     elif name == "download_model":
         from .hf_utils import download_model
         return download_model
@@ -36,6 +47,8 @@ __all__ = [
     # Config
     "LoRAConfig",
     "TrainingConfig", 
+    "GRPOConfig",
+    "RewardConfig",
     "ModelConfig",
     "HuggingFaceConfig",
     "Config",
@@ -58,4 +71,6 @@ __all__ = [
     # Trainers (lazy)
     "LoRATrainer",
     "KFoldTrainer",
+    "GRPOTrainer",
+    "GRPOKFoldTrainer",
 ]

--- a/src/config.py
+++ b/src/config.py
@@ -9,7 +9,7 @@ This module provides dataclass-based configurations for:
 """
 
 from dataclasses import dataclass, field
-from typing import Optional, List
+from typing import Optional, List, Dict
 from pathlib import Path
 import yaml
 import os
@@ -126,8 +126,15 @@ class DataConfig:
     valid_file: str = "data/processed/valid.jsonl"
     prompt_template: Optional[str] = None
     
+    # RL data paths (GRPO)
+    rl_train_file: str = "data/processed/rl_train.jsonl"
+    rl_valid_file: str = "data/processed/rl_valid.jsonl"
+    rl_eval_file: str = "data/processed/rl_eval.jsonl"
+
+    # Training method
+    training_method: str = "basic"  # "basic", "kfold", "grpo", or "grpo_kfold"
+
     # K-Fold Cross-Validation settings
-    training_method: str = "basic"  # "basic" or "kfold"
     kfold_splits: int = 5  # Number of folds (3-10)
     kfold_seed: int = 42  # Seed for reproducibility
     
@@ -136,10 +143,82 @@ class DataConfig:
         return {
             "train_file": self.train_file,
             "valid_file": self.valid_file,
+            "rl_train_file": self.rl_train_file,
+            "rl_valid_file": self.rl_valid_file,
+            "rl_eval_file": self.rl_eval_file,
             "prompt_template": self.prompt_template,
             "training_method": self.training_method,
             "kfold_splits": self.kfold_splits,
             "kfold_seed": self.kfold_seed,
+        }
+
+
+@dataclass
+class GRPOConfig:
+    """Configuration for GRPO (Group Relative Policy Optimization) training."""
+
+    group_size: int = 4
+    clip_epsilon: float = 0.2
+    beta_kl: float = 0.02
+    advantage_epsilon: float = 1e-8
+
+    # Generation settings
+    max_generation_tokens: int = 128
+    temperature: float = 0.8
+    top_p: float = 1.0
+
+    # Training loop behavior
+    warmup_epochs: int = 1
+    preflight_sample_size: int = 128
+    min_reward_std: float = 1e-6
+    eval_steps: int = 50
+    logging_steps: int = 10
+
+    def to_dict(self) -> dict:
+        """Convert config to dictionary."""
+        return {
+            "group_size": self.group_size,
+            "clip_epsilon": self.clip_epsilon,
+            "beta_kl": self.beta_kl,
+            "advantage_epsilon": self.advantage_epsilon,
+            "max_generation_tokens": self.max_generation_tokens,
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+            "warmup_epochs": self.warmup_epochs,
+            "preflight_sample_size": self.preflight_sample_size,
+            "min_reward_std": self.min_reward_std,
+            "eval_steps": self.eval_steps,
+            "logging_steps": self.logging_steps,
+        }
+
+
+@dataclass
+class RewardConfig:
+    """Configuration for rule-based reward computation in GRPO."""
+
+    function: str = "weighted_rules"
+    weights: Dict[str, float] = field(default_factory=lambda: {
+        "exact_match": 0.4,
+        "keyword_coverage": 0.3,
+        "json_format": 0.2,
+        "length_band": 0.1,
+    })
+    pass_threshold: float = 0.6
+    metadata_keyword_field: str = "keywords"
+    min_response_length: int = 16
+    max_response_length: int = 512
+    require_nonzero_variance: bool = True
+
+    def to_dict(self) -> dict:
+        """Convert config to dictionary."""
+        return {
+            "function": self.function,
+            "weights": self.weights,
+            "pass_threshold": self.pass_threshold,
+            "metadata_keyword_field": self.metadata_keyword_field,
+            "min_response_length": self.min_response_length,
+            "max_response_length": self.max_response_length,
+            "require_nonzero_variance": self.require_nonzero_variance,
         }
 
 
@@ -174,6 +253,8 @@ class Config:
     model: ModelConfig = field(default_factory=ModelConfig)
     lora: LoRAConfig = field(default_factory=LoRAConfig)
     training: TrainingConfig = field(default_factory=TrainingConfig)
+    grpo: GRPOConfig = field(default_factory=GRPOConfig)
+    reward: RewardConfig = field(default_factory=RewardConfig)
     data: DataConfig = field(default_factory=DataConfig)
     output: OutputConfig = field(default_factory=OutputConfig)
     huggingface: HuggingFaceConfig = field(default_factory=HuggingFaceConfig)
@@ -188,6 +269,8 @@ class Config:
             model=ModelConfig(**data.get("model", {})),
             lora=LoRAConfig(**data.get("lora", {})),
             training=TrainingConfig(**data.get("training", {})),
+            grpo=GRPOConfig(**data.get("grpo", {})),
+            reward=RewardConfig(**data.get("reward", {})),
             data=DataConfig(**data.get("data", {})),
             output=OutputConfig(**data.get("output", {})),
             huggingface=HuggingFaceConfig(**data.get("huggingface", {})),
@@ -199,6 +282,8 @@ class Config:
             "model": self.model.to_dict(),
             "lora": self.lora.to_dict(),
             "training": self.training.to_dict(),
+            "grpo": self.grpo.to_dict(),
+            "reward": self.reward.to_dict(),
             "data": self.data.to_dict(),
             "output": self.output.to_dict(),
             "huggingface": self.huggingface.to_dict(),

--- a/src/data_utils.py
+++ b/src/data_utils.py
@@ -463,6 +463,7 @@ def preprocess_raw_text(
     chunk_overlap: int = 100,
     clean_timestamps: bool = True,
     clean_urls: bool = False,
+    clean_speaker_labels: bool = False,
     topic: str = "the content",
 ) -> List[Dict[str, str]]:
     """
@@ -475,6 +476,7 @@ def preprocess_raw_text(
         chunk_overlap: Overlap between chunks
         clean_timestamps: Remove timestamps
         clean_urls: Remove URLs
+        clean_speaker_labels: Remove speaker labels
         topic: Topic for knowledge format
     
     Returns:
@@ -485,6 +487,7 @@ def preprocess_raw_text(
         text,
         remove_timestamps=clean_timestamps,
         remove_urls=clean_urls,
+        remove_speaker_labels=clean_speaker_labels,
         normalize_whitespace=True,
     )
     
@@ -571,6 +574,7 @@ def process_folder(
     chunk_size: int = 1000,
     clean_timestamps: bool = True,
     clean_urls: bool = False,
+    clean_speaker_labels: bool = False,
     topic: str = "the content",
     progress_callback: callable = None,
 ) -> Tuple[Path, Path]:
@@ -586,6 +590,7 @@ def process_folder(
         chunk_size: Chunk size for splitting
         clean_timestamps: Remove timestamps
         clean_urls: Remove URLs
+        clean_speaker_labels: Remove speaker labels
         topic: Topic for knowledge format
         progress_callback: Optional callback(current, total, filename) for progress
     
@@ -623,6 +628,7 @@ def process_folder(
                 chunk_overlap=100,
                 clean_timestamps=clean_timestamps,
                 clean_urls=clean_urls,
+                clean_speaker_labels=clean_speaker_labels,
                 topic=topic,
             )
             all_examples.extend(examples)
@@ -844,6 +850,7 @@ def preprocess_with_llm(
     chunk_overlap: int = 100,
     clean_timestamps: bool = True,
     clean_urls: bool = False,
+    clean_speaker_labels: bool = False,
     questions_per_chunk: int = 2,
     progress_callback: callable = None,
 ) -> List[Dict[str, str]]:
@@ -859,6 +866,7 @@ def preprocess_with_llm(
         chunk_overlap: Overlap between chunks
         clean_timestamps: Remove timestamps
         clean_urls: Remove URLs
+        clean_speaker_labels: Remove speaker labels
         questions_per_chunk: Number of Q&A pairs per chunk (for qa format)
         progress_callback: Optional callback for progress
     
@@ -870,6 +878,7 @@ def preprocess_with_llm(
         text,
         remove_timestamps=clean_timestamps,
         remove_urls=clean_urls,
+        remove_speaker_labels=clean_speaker_labels,
         normalize_whitespace=True,
     )
     
@@ -1201,6 +1210,7 @@ def preprocess_with_openrouter(
     chunk_overlap: int = 100,
     clean_timestamps: bool = True,
     clean_urls: bool = False,
+    clean_speaker_labels: bool = False,
     questions_per_chunk: int = 2,
     api_key: Optional[str] = None,
     model: Optional[str] = None,
@@ -1216,6 +1226,7 @@ def preprocess_with_openrouter(
         chunk_overlap: Overlap between chunks
         clean_timestamps: Remove timestamps
         clean_urls: Remove URLs
+        clean_speaker_labels: Remove speaker labels
         questions_per_chunk: Number of Q&A pairs per chunk (for qa format)
         api_key: Open Router API key
         model: Model to use
@@ -1229,6 +1240,7 @@ def preprocess_with_openrouter(
         text,
         remove_timestamps=clean_timestamps,
         remove_urls=clean_urls,
+        remove_speaker_labels=clean_speaker_labels,
         normalize_whitespace=True,
     )
     
@@ -1268,6 +1280,7 @@ def preprocess_with_agents(
     chunk_overlap: int = 200,
     clean_timestamps: bool = True,
     clean_urls: bool = False,
+    clean_speaker_labels: bool = False,
     questions_per_chunk: int = 2,
     api_key: Optional[str] = None,
     meta_model: Optional[str] = None,
@@ -1294,6 +1307,7 @@ def preprocess_with_agents(
         chunk_overlap: Overlap between chunks
         clean_timestamps: Remove timestamps
         clean_urls: Remove URLs
+        clean_speaker_labels: Remove speaker labels
         questions_per_chunk: Number of Q&A pairs per chunk
         api_key: OpenRouter API key
         meta_model: Model for Meta-Agent (smarter model recommended)
@@ -1312,6 +1326,7 @@ def preprocess_with_agents(
         text,
         remove_timestamps=clean_timestamps,
         remove_urls=clean_urls,
+        remove_speaker_labels=clean_speaker_labels,
         normalize_whitespace=True,
     )
     
@@ -1418,4 +1433,3 @@ def process_with_agents(
     print(f"Saved {len(val_data)} validation examples to {val_path}")
     
     return train_path, val_path, specialized_prompt
-

--- a/src/grpo_trainer.py
+++ b/src/grpo_trainer.py
@@ -1,0 +1,662 @@
+"""GRPO training engine built on top of MLX LoRA models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import json
+from pathlib import Path
+import time
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.optimizers as optim
+
+from src.data_utils import create_kfold_splits, get_kfold_data
+from src.param_utils import flatten_params
+from src.rewards import compute_reward
+from src.trainer import LoRATrainer
+
+
+@dataclass
+class GRPOStepMetrics:
+    """Container for GRPO step metrics."""
+
+    step: int
+    policy_loss: float
+    kl_loss: float
+    total_loss: float
+    mean_reward: float
+    std_reward: float
+    learning_rate: float
+    tokens_per_second: float
+    elapsed_time: float
+
+
+class GRPOTrainer:
+    """Group Relative Policy Optimization trainer for LoRA models."""
+
+    def __init__(
+        self,
+        model: nn.Module,
+        reference_model: nn.Module,
+        tokenizer: Any,
+        train_data: List[Dict[str, Any]],
+        reward_config: Mapping[str, Any],
+        val_data: Optional[List[Dict[str, Any]]] = None,
+        learning_rate: float = 1e-5,
+        batch_size: int = 2,
+        num_epochs: int = 1,
+        group_size: int = 4,
+        clip_epsilon: float = 0.2,
+        beta_kl: float = 0.02,
+        advantage_epsilon: float = 1e-8,
+        max_seq_length: int = 2048,
+        max_generation_tokens: int = 128,
+        temperature: float = 0.8,
+        top_p: float = 1.0,
+        save_steps: int = 500,
+        eval_steps: int = 50,
+        logging_steps: int = 10,
+        output_dir: Union[str, Path] = "outputs",
+        prompt_template: Optional[str] = None,
+        model_name: Optional[str] = None,
+        lora_config: Optional[Dict[str, Any]] = None,
+        callbacks: Optional[Dict[str, Callable]] = None,
+    ):
+        self.model = model
+        self.reference_model = reference_model
+        self.tokenizer = tokenizer
+        self.train_data = train_data
+        self.val_data = val_data or []
+        self.reward_config = dict(reward_config)
+
+        self.learning_rate = learning_rate
+        self.batch_size = batch_size
+        self.num_epochs = num_epochs
+        self.group_size = group_size
+        self.clip_epsilon = clip_epsilon
+        self.beta_kl = beta_kl
+        self.advantage_epsilon = advantage_epsilon
+
+        self.max_seq_length = max_seq_length
+        self.max_generation_tokens = max_generation_tokens
+        self.temperature = temperature
+        self.top_p = top_p
+
+        self.save_steps = save_steps
+        self.eval_steps = eval_steps
+        self.logging_steps = logging_steps
+
+        self.prompt_template = prompt_template
+        self.model_name = model_name
+        self.lora_config = lora_config or {}
+        self.callbacks = callbacks or {}
+
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.logs_dir = self.output_dir / "logs"
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        self.log_file = self.logs_dir / "training_log.jsonl"
+
+        self.global_step = 0
+        self.epoch = 0
+        self.best_eval_reward = float("-inf")
+
+    @staticmethod
+    def compute_group_advantages(rewards: List[float], eps: float = 1e-8) -> List[float]:
+        """Compute normalized relative advantages for a reward group."""
+        if not rewards:
+            return []
+        mean = sum(rewards) / len(rewards)
+        var = sum((r - mean) ** 2 for r in rewards) / len(rewards)
+        std = var ** 0.5
+        denom = std + eps
+        return [(r - mean) / denom for r in rewards]
+
+    @staticmethod
+    def clipped_policy_objective(ratio: float, advantage: float, clip_epsilon: float) -> float:
+        """PPO-style clipped policy objective used by GRPO."""
+        clipped = min(max(ratio, 1.0 - clip_epsilon), 1.0 + clip_epsilon)
+        return min(ratio * advantage, clipped * advantage)
+
+    def _write_log_entry(self, entry: Dict[str, Any]) -> None:
+        entry["timestamp"] = datetime.now().isoformat()
+        with open(self.log_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+
+    def _batch_iterate(self, data: List[Dict[str, Any]]):
+        for i in range(0, len(data), self.batch_size):
+            yield data[i:i + self.batch_size]
+
+    def _format_prompt(self, prompt: str) -> str:
+        if not self.prompt_template:
+            return prompt
+        template = self.prompt_template
+        if "{response}" in template:
+            template = template.split("{response}")[0]
+        try:
+            return template.format(instruction=prompt)
+        except Exception:
+            return prompt
+
+    def _safe_generate(self, prompt: str) -> str:
+        from mlx_lm import generate
+
+        kwargs = {
+            "prompt": prompt,
+            "max_tokens": self.max_generation_tokens,
+            "verbose": False,
+        }
+        try:
+            return generate(
+                self.model,
+                self.tokenizer,
+                temperature=self.temperature,
+                top_p=self.top_p,
+                **kwargs,
+            )
+        except TypeError:
+            return generate(self.model, self.tokenizer, **kwargs)
+
+    def _tokenize_completion_window(self, prompt: str, response: str) -> Tuple[List[int], int]:
+        formatted_prompt = self._format_prompt(prompt)
+        prompt_tokens = self.tokenizer.encode(formatted_prompt)
+        full_tokens = self.tokenizer.encode(formatted_prompt + response)
+
+        if len(full_tokens) > self.max_seq_length:
+            full_tokens = full_tokens[: self.max_seq_length]
+        prompt_len = min(len(prompt_tokens), max(0, len(full_tokens) - 1))
+        return full_tokens, prompt_len
+
+    def _sequence_logprob_and_kl(
+        self,
+        model: nn.Module,
+        prompt: str,
+        response: str,
+    ) -> Tuple[mx.array, mx.array]:
+        full_tokens, prompt_len = self._tokenize_completion_window(prompt, response)
+        if len(full_tokens) < 2 or prompt_len >= len(full_tokens) - 1:
+            return mx.array(0.0), mx.array(0.0)
+
+        input_ids = mx.array(full_tokens[:-1])[None, :]
+        targets = mx.array(full_tokens[1:])[None, :]
+
+        logits = model(input_ids)
+
+        start = max(prompt_len - 1, 0)
+        completion_logits = logits[:, start:, :]
+        completion_targets = targets[:, start:]
+
+        if completion_targets.size == 0:
+            return mx.array(0.0), mx.array(0.0)
+
+        vocab_size = completion_logits.shape[-1]
+        ce = nn.losses.cross_entropy(
+            completion_logits.reshape(-1, vocab_size),
+            completion_targets.reshape(-1),
+        )
+        logprob = -ce.sum()
+
+        kl = mx.array(0.0)
+        if self.reference_model is not None:
+            ref_logits = self.reference_model(input_ids)[:, start:, :]
+            current_log_probs = completion_logits - mx.logsumexp(completion_logits, axis=-1, keepdims=True)
+            ref_log_probs = ref_logits - mx.logsumexp(ref_logits, axis=-1, keepdims=True)
+            p_current = mx.exp(current_log_probs)
+            kl = (p_current * (current_log_probs - ref_log_probs)).sum(axis=-1).mean()
+
+        return logprob, kl
+
+    def _prepare_trajectories(self, batch: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], float, float, int]:
+        trajectories: List[Dict[str, Any]] = []
+        all_rewards: List[float] = []
+        total_tokens = 0
+
+        for sample in batch:
+            prompt = str(sample.get("prompt", "")).strip()
+            if not prompt:
+                continue
+
+            responses = [self._safe_generate(self._format_prompt(prompt)) for _ in range(self.group_size)]
+            rewards = [compute_reward(sample, r, self.reward_config).total_score for r in responses]
+            advantages = self.compute_group_advantages(rewards, eps=self.advantage_epsilon)
+
+            for response, reward, advantage in zip(responses, rewards, advantages):
+                old_logprob, _ = self._sequence_logprob_and_kl(self.model, prompt, response)
+                old_logprob_value = float(old_logprob.item())
+                trajectories.append(
+                    {
+                        "prompt": prompt,
+                        "response": response,
+                        "old_logprob": old_logprob_value,
+                        "advantage": float(advantage),
+                        "reward": float(reward),
+                    }
+                )
+                all_rewards.append(float(reward))
+
+                full_tokens, prompt_len = self._tokenize_completion_window(prompt, response)
+                completion_tokens = max(0, len(full_tokens) - prompt_len)
+                total_tokens += completion_tokens
+
+        if not all_rewards:
+            return trajectories, 0.0, 0.0, total_tokens
+
+        mean_r = sum(all_rewards) / len(all_rewards)
+        std_r = (sum((r - mean_r) ** 2 for r in all_rewards) / len(all_rewards)) ** 0.5
+        return trajectories, mean_r, std_r, total_tokens
+
+    def _evaluate_mean_reward(self, data: List[Dict[str, Any]]) -> float:
+        if not data:
+            return 0.0
+
+        scores: List[float] = []
+        for sample in data:
+            prompt = str(sample.get("prompt", "")).strip()
+            if not prompt:
+                continue
+            response = self._safe_generate(self._format_prompt(prompt))
+            out = compute_reward(sample, response, self.reward_config)
+            scores.append(out.total_score)
+
+        return sum(scores) / len(scores) if scores else 0.0
+
+    def _log_step(self, metrics: GRPOStepMetrics) -> None:
+        self._write_log_entry(
+            {
+                "type": "grpo_step",
+                "step": metrics.step,
+                "epoch": self.epoch,
+                "policy_loss": metrics.policy_loss,
+                "kl_loss": metrics.kl_loss,
+                "total_loss": metrics.total_loss,
+                "mean_reward": metrics.mean_reward,
+                "std_reward": metrics.std_reward,
+                "learning_rate": metrics.learning_rate,
+                "tokens_per_second": metrics.tokens_per_second,
+                "elapsed_time": metrics.elapsed_time,
+            }
+        )
+
+    def _save_checkpoint(self, name: str) -> None:
+        checkpoint_dir = self.output_dir / "checkpoints" / name
+        checkpoint_dir.mkdir(parents=True, exist_ok=True)
+
+        trainable_params = flatten_params(self.model.trainable_parameters())
+        mx.save_safetensors(str(checkpoint_dir / "adapters.safetensors"), trainable_params)
+
+        state = {
+            "global_step": self.global_step,
+            "epoch": self.epoch,
+            "best_eval_reward": self.best_eval_reward,
+            "beta_kl": self.beta_kl,
+            "group_size": self.group_size,
+        }
+        with open(checkpoint_dir / "grpo_state.json", "w", encoding="utf-8") as f:
+            json.dump(state, f, indent=2)
+
+    def train(self) -> Dict[str, Any]:
+        """Run GRPO training loop."""
+        if not self.train_data:
+            raise ValueError("GRPO training data is empty")
+
+        self._write_log_entry(
+            {
+                "type": "grpo_start",
+                "model_name": self.model_name,
+                "lora_config": self.lora_config,
+                "grpo_config": {
+                    "group_size": self.group_size,
+                    "clip_epsilon": self.clip_epsilon,
+                    "beta_kl": self.beta_kl,
+                    "max_generation_tokens": self.max_generation_tokens,
+                    "temperature": self.temperature,
+                    "top_p": self.top_p,
+                },
+                "reward_config": self.reward_config,
+                "train_samples": len(self.train_data),
+                "val_samples": len(self.val_data),
+            }
+        )
+
+        optimizer = optim.AdamW(learning_rate=self.learning_rate, weight_decay=0.0)
+
+        def loss_components(model, trajectories):
+            policy_total = mx.array(0.0)
+            kl_total = mx.array(0.0)
+
+            for traj in trajectories:
+                current_logprob, kl_value = self._sequence_logprob_and_kl(
+                    model,
+                    traj["prompt"],
+                    traj["response"],
+                )
+                old_logprob = mx.array(traj["old_logprob"])
+                advantage = mx.array(traj["advantage"])
+
+                ratio = mx.exp(current_logprob - old_logprob)
+                clipped_ratio = mx.clip(ratio, 1.0 - self.clip_epsilon, 1.0 + self.clip_epsilon)
+                policy_obj = mx.minimum(ratio * advantage, clipped_ratio * advantage)
+
+                policy_total = policy_total - policy_obj
+                kl_total = kl_total + kl_value
+
+            denom = max(1, len(trajectories))
+            policy_mean = policy_total / denom
+            kl_mean = kl_total / denom
+            total = policy_mean + self.beta_kl * kl_mean
+            return policy_mean, kl_mean, total
+
+        def loss_fn(model, trajectories):
+            _, _, total = loss_components(model, trajectories)
+            return total
+
+        loss_and_grad = nn.value_and_grad(self.model, loss_fn)
+
+        start_time = time.time()
+        total_tokens = 0
+        last_policy_loss = 0.0
+        last_kl_loss = 0.0
+        last_total_loss = 0.0
+
+        for epoch in range(self.num_epochs):
+            self.epoch = epoch
+            for batch in self._batch_iterate(self.train_data):
+                trajectories, mean_reward, std_reward, batch_tokens = self._prepare_trajectories(batch)
+                if not trajectories:
+                    continue
+
+                loss, grads = loss_and_grad(self.model, trajectories)
+                optimizer.update(self.model, grads)
+                mx.eval(self.model.parameters(), optimizer.state)
+
+                self.global_step += 1
+                total_tokens += batch_tokens
+
+                # Compute detailed metrics for observability.
+                policy_loss, kl_loss, total_loss = loss_components(self.model, trajectories)
+                last_policy_loss = float(policy_loss.item())
+                last_kl_loss = float(kl_loss.item())
+                last_total_loss = float(total_loss.item())
+
+                if self.global_step % self.logging_steps == 0:
+                    elapsed = time.time() - start_time
+                    metrics = GRPOStepMetrics(
+                        step=self.global_step,
+                        policy_loss=last_policy_loss,
+                        kl_loss=last_kl_loss,
+                        total_loss=last_total_loss,
+                        mean_reward=mean_reward,
+                        std_reward=std_reward,
+                        learning_rate=float(optimizer.learning_rate),
+                        tokens_per_second=(total_tokens / elapsed) if elapsed > 0 else 0.0,
+                        elapsed_time=elapsed,
+                    )
+                    self._log_step(metrics)
+
+                if self.val_data and self.global_step % self.eval_steps == 0:
+                    eval_reward = self._evaluate_mean_reward(self.val_data)
+                    self._write_log_entry(
+                        {
+                            "type": "grpo_eval",
+                            "step": self.global_step,
+                            "epoch": self.epoch,
+                            "mean_reward": eval_reward,
+                            "elapsed_time": time.time() - start_time,
+                        }
+                    )
+                    if eval_reward > self.best_eval_reward:
+                        self.best_eval_reward = eval_reward
+                        self._save_checkpoint("best")
+
+                if self.global_step % self.save_steps == 0:
+                    self._save_checkpoint(f"step-{self.global_step}")
+
+        self._save_checkpoint("final")
+
+        total_time = time.time() - start_time
+        final_eval_reward = self._evaluate_mean_reward(self.val_data) if self.val_data else None
+        if final_eval_reward is not None and final_eval_reward > self.best_eval_reward:
+            self.best_eval_reward = final_eval_reward
+
+        summary = {
+            "total_steps": self.global_step,
+            "total_time": total_time,
+            "final_total_loss": last_total_loss,
+            "final_policy_loss": last_policy_loss,
+            "final_kl_loss": last_kl_loss,
+            "best_eval_reward": None if self.best_eval_reward == float("-inf") else self.best_eval_reward,
+        }
+
+        self._write_log_entry({"type": "grpo_end", **summary})
+        return summary
+
+
+class GRPOKFoldTrainer:
+    """K-Fold wrapper that trains a fresh GRPO model per fold."""
+
+    def __init__(
+        self,
+        model_loader: Callable[[], nn.Module],
+        reference_model_loader: Callable[[], nn.Module],
+        tokenizer: Any,
+        full_data: List[Dict[str, Any]],
+        reward_config: Mapping[str, Any],
+        k: int = 5,
+        seed: int = 42,
+        learning_rate: float = 1e-5,
+        batch_size: int = 2,
+        num_epochs: int = 1,
+        group_size: int = 4,
+        clip_epsilon: float = 0.2,
+        beta_kl: float = 0.02,
+        advantage_epsilon: float = 1e-8,
+        max_seq_length: int = 2048,
+        max_generation_tokens: int = 128,
+        temperature: float = 0.8,
+        top_p: float = 1.0,
+        save_steps: int = 500,
+        eval_steps: int = 50,
+        logging_steps: int = 10,
+        output_dir: Union[str, Path] = "outputs",
+        prompt_template: Optional[str] = None,
+        model_name: Optional[str] = None,
+        lora_config: Optional[Dict[str, Any]] = None,
+        warmup_epochs: int = 1,
+        warmup_learning_rate: Optional[float] = None,
+    ):
+        self.model_loader = model_loader
+        self.reference_model_loader = reference_model_loader
+        self.tokenizer = tokenizer
+        self.full_data = full_data
+        self.reward_config = dict(reward_config)
+
+        self.k = k
+        self.seed = seed
+
+        self.learning_rate = learning_rate
+        self.batch_size = batch_size
+        self.num_epochs = num_epochs
+        self.group_size = group_size
+        self.clip_epsilon = clip_epsilon
+        self.beta_kl = beta_kl
+        self.advantage_epsilon = advantage_epsilon
+
+        self.max_seq_length = max_seq_length
+        self.max_generation_tokens = max_generation_tokens
+        self.temperature = temperature
+        self.top_p = top_p
+
+        self.save_steps = save_steps
+        self.eval_steps = eval_steps
+        self.logging_steps = logging_steps
+
+        self.prompt_template = prompt_template
+        self.model_name = model_name
+        self.lora_config = lora_config or {}
+        self.warmup_epochs = warmup_epochs
+        self.warmup_learning_rate = warmup_learning_rate
+
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.logs_dir = self.output_dir / "logs"
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        self.log_file = self.logs_dir / "training_log.jsonl"
+
+    def _to_sft_examples(self, samples: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+        """Convert RL prompt/reference samples into SFT text examples."""
+        examples: List[Dict[str, str]] = []
+        for item in samples:
+            prompt = str(item.get("prompt", "")).strip()
+            reference = str(item.get("reference", "")).strip()
+            if not prompt or not reference:
+                continue
+            if self.prompt_template:
+                try:
+                    text = self.prompt_template.format(instruction=prompt, response=reference)
+                except Exception:
+                    text = f"### Instruction:\n{prompt}\n\n### Response:\n{reference}"
+            else:
+                text = f"### Instruction:\n{prompt}\n\n### Response:\n{reference}"
+            examples.append({"text": text})
+        return examples
+
+    def _write_log_entry(self, entry: Dict[str, Any]) -> None:
+        entry["timestamp"] = datetime.now().isoformat()
+        with open(self.log_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+
+    def train(self) -> Dict[str, Any]:
+        if not self.full_data:
+            raise ValueError("GRPO K-Fold requires non-empty data")
+
+        splits = create_kfold_splits(self.full_data, k=self.k, seed=self.seed)
+        self._write_log_entry(
+            {
+                "type": "grpo_kfold_start",
+                "k": self.k,
+                "total_samples": len(self.full_data),
+                "reward_config": self.reward_config,
+            }
+        )
+
+        fold_results: List[Dict[str, Any]] = []
+        best_fold = 0
+        best_reward = float("-inf")
+        start_time = time.time()
+
+        for fold_idx in range(self.k):
+            train_data, val_data = get_kfold_data(self.full_data, splits, fold_idx)
+            self._write_log_entry(
+                {
+                    "type": "grpo_fold_start",
+                    "fold": fold_idx,
+                    "total_folds": self.k,
+                    "train_samples": len(train_data),
+                    "val_samples": len(val_data),
+                }
+            )
+
+            model = self.model_loader()
+            reference_model = self.reference_model_loader()
+
+            fold_output_dir = self.output_dir / f"fold_{fold_idx}"
+
+            if self.warmup_epochs > 0:
+                warmup_train = self._to_sft_examples(train_data)
+                warmup_val = self._to_sft_examples(val_data)
+                warmup_trainer = LoRATrainer(
+                    model=model,
+                    tokenizer=self.tokenizer,
+                    train_data=warmup_train,
+                    val_data=warmup_val,
+                    learning_rate=self.warmup_learning_rate or self.learning_rate,
+                    batch_size=self.batch_size,
+                    num_epochs=self.warmup_epochs,
+                    warmup_steps=0,
+                    weight_decay=0.0,
+                    max_seq_length=self.max_seq_length,
+                    save_steps=10_000_000,
+                    eval_steps=10_000_000,
+                    logging_steps=10_000_000,
+                    output_dir=fold_output_dir,
+                    model_name=self.model_name,
+                    lora_config=self.lora_config,
+                )
+                warmup_trainer.log_file = self.log_file
+                warmup_trainer.train()
+                warmup_trainer._save_checkpoint("pretrain")
+
+                pretrain_adapters = mx.load(str(fold_output_dir / "checkpoints" / "pretrain" / "adapters.safetensors"))
+                reference_model.load_weights(list(pretrain_adapters.items()), strict=False)
+                model.load_weights(list(pretrain_adapters.items()), strict=False)
+
+            trainer = GRPOTrainer(
+                model=model,
+                reference_model=reference_model,
+                tokenizer=self.tokenizer,
+                train_data=train_data,
+                val_data=val_data,
+                reward_config=self.reward_config,
+                learning_rate=self.learning_rate,
+                batch_size=self.batch_size,
+                num_epochs=self.num_epochs,
+                group_size=self.group_size,
+                clip_epsilon=self.clip_epsilon,
+                beta_kl=self.beta_kl,
+                advantage_epsilon=self.advantage_epsilon,
+                max_seq_length=self.max_seq_length,
+                max_generation_tokens=self.max_generation_tokens,
+                temperature=self.temperature,
+                top_p=self.top_p,
+                save_steps=self.save_steps,
+                eval_steps=self.eval_steps,
+                logging_steps=self.logging_steps,
+                output_dir=fold_output_dir,
+                prompt_template=self.prompt_template,
+                model_name=self.model_name,
+                lora_config=self.lora_config,
+            )
+            trainer.log_file = self.log_file
+
+            result = trainer.train()
+            result["fold"] = fold_idx
+            result["train_samples"] = len(train_data)
+            result["val_samples"] = len(val_data)
+            fold_results.append(result)
+
+            fold_reward = result.get("best_eval_reward")
+            if fold_reward is not None and fold_reward > best_reward:
+                best_reward = fold_reward
+                best_fold = fold_idx
+
+            self._write_log_entry(
+                {
+                    "type": "grpo_fold_end",
+                    "fold": fold_idx,
+                    "total_folds": self.k,
+                    "fold_result": result,
+                }
+            )
+
+        rewards = [r.get("best_eval_reward", 0.0) or 0.0 for r in fold_results]
+        avg_reward = sum(rewards) / len(rewards)
+        std_reward = (sum((r - avg_reward) ** 2 for r in rewards) / len(rewards)) ** 0.5
+
+        summary = {
+            "k": self.k,
+            "total_time": time.time() - start_time,
+            "avg_best_reward": avg_reward,
+            "std_best_reward": std_reward,
+            "best_fold": best_fold,
+            "best_reward": best_reward,
+            "fold_results": fold_results,
+        }
+
+        with open(self.output_dir / "grpo_kfold_summary.json", "w", encoding="utf-8") as f:
+            json.dump(summary, f, indent=2)
+
+        self._write_log_entry({"type": "grpo_kfold_end", **summary})
+        return summary

--- a/src/rewards.py
+++ b/src/rewards.py
@@ -1,0 +1,167 @@
+"""Rule-based reward functions for GRPO training."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import math
+import re
+from typing import Any, Callable, Dict, Mapping
+
+
+@dataclass
+class RewardInput:
+    """Input bundle used for reward computation."""
+
+    sample: Dict[str, Any]
+    response: str
+
+
+@dataclass
+class RewardOutput:
+    """Structured reward output with per-component details."""
+
+    total_score: float
+    pass_threshold: float
+    passed: bool
+    components: Dict[str, float]
+
+
+RewardFn = Callable[[Dict[str, Any], str, Mapping[str, Any]], float]
+
+
+def _get_config_value(config: Mapping[str, Any], key: str, default: Any) -> Any:
+    return config.get(key, default)
+
+
+def _normalize_text(text: str) -> str:
+    text = text.lower().strip()
+    text = re.sub(r"\s+", " ", text)
+    return text
+
+
+def reward_exact_match(sample: Dict[str, Any], response: str, config: Mapping[str, Any]) -> float:
+    """Binary exact match against the sample reference."""
+    reference = str(sample.get("reference", "")).strip()
+    if not reference:
+        return 0.0
+
+    normalize = bool(_get_config_value(config, "normalize_text", True))
+    if normalize:
+        return 1.0 if _normalize_text(reference) == _normalize_text(response) else 0.0
+    return 1.0 if reference.strip() == response.strip() else 0.0
+
+
+def reward_keyword_coverage(sample: Dict[str, Any], response: str, config: Mapping[str, Any]) -> float:
+    """Coverage of required keywords from metadata or reference text."""
+    metadata = sample.get("metadata") or {}
+    keyword_field = str(_get_config_value(config, "metadata_keyword_field", "keywords"))
+
+    keywords = metadata.get(keyword_field)
+    if keywords is None:
+        reference = str(sample.get("reference", "")).strip()
+        if not reference:
+            return 0.0
+        # Fallback: extract a lightweight keyword set from reference tokens.
+        tokens = [tok for tok in re.findall(r"[A-Za-z0-9_]+", reference.lower()) if len(tok) > 3]
+        keywords = sorted(set(tokens[:10]))
+
+    if not isinstance(keywords, list) or not keywords:
+        return 0.0
+
+    resp = _normalize_text(response)
+    hits = 0
+    for kw in keywords:
+        kw_norm = _normalize_text(str(kw))
+        if kw_norm and kw_norm in resp:
+            hits += 1
+    return hits / len(keywords)
+
+
+def reward_json_format(sample: Dict[str, Any], response: str, config: Mapping[str, Any]) -> float:
+    """Checks whether response is valid JSON."""
+    text = response.strip()
+    if not text:
+        return 0.0
+    try:
+        json.loads(text)
+        return 1.0
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return 0.0
+
+
+def reward_length_band(sample: Dict[str, Any], response: str, config: Mapping[str, Any]) -> float:
+    """Rewards responses that stay inside a configured length band."""
+    min_len = int(_get_config_value(config, "min_response_length", 16))
+    max_len = int(_get_config_value(config, "max_response_length", 512))
+
+    n = len(response.strip())
+    if min_len <= n <= max_len:
+        return 1.0
+    if n < min_len:
+        return max(0.0, n / max(min_len, 1))
+    # n > max_len
+    overflow = n - max_len
+    return max(0.0, 1.0 - overflow / max(max_len, 1))
+
+
+def _weighted_rules(sample: Dict[str, Any], response: str, config: Mapping[str, Any]) -> Dict[str, float]:
+    weights = dict(_get_config_value(config, "weights", {}))
+    if not weights:
+        weights = {
+            "exact_match": 0.4,
+            "keyword_coverage": 0.3,
+            "json_format": 0.2,
+            "length_band": 0.1,
+        }
+
+    total_w = sum(max(0.0, float(w)) for w in weights.values())
+    if total_w <= 0:
+        total_w = 1.0
+
+    components: Dict[str, float] = {}
+    for name, weight in weights.items():
+        fn = REWARD_REGISTRY.get(name)
+        if fn is None:
+            components[name] = 0.0
+            continue
+        value = fn(sample, response, config)
+        if math.isnan(value) or math.isinf(value):
+            value = 0.0
+        components[name] = max(0.0, min(1.0, float(value))) * max(0.0, float(weight)) / total_w
+
+    return components
+
+
+REWARD_REGISTRY: Dict[str, RewardFn] = {
+    "exact_match": reward_exact_match,
+    "keyword_coverage": reward_keyword_coverage,
+    "json_format": reward_json_format,
+    "length_band": reward_length_band,
+}
+
+
+def compute_reward(sample: Dict[str, Any], response: str, config: Mapping[str, Any]) -> RewardOutput:
+    """Compute reward for a sample/response pair using configured rule set."""
+    reward_function = str(_get_config_value(config, "function", "weighted_rules"))
+    pass_threshold = float(_get_config_value(config, "pass_threshold", 0.6))
+
+    if reward_function == "weighted_rules":
+        components = _weighted_rules(sample, response, config)
+        total = float(sum(components.values()))
+    else:
+        fn = REWARD_REGISTRY.get(reward_function)
+        if fn is None:
+            raise ValueError(f"Unknown reward function: {reward_function}")
+        raw = fn(sample, response, config)
+        if math.isnan(raw) or math.isinf(raw):
+            raw = 0.0
+        total = max(0.0, min(1.0, float(raw)))
+        components = {reward_function: total}
+
+    return RewardOutput(
+        total_score=total,
+        pass_threshold=pass_threshold,
+        passed=total >= pass_threshold,
+        components=components,
+    )

--- a/src/rl_data.py
+++ b/src/rl_data.py
@@ -1,0 +1,312 @@
+"""RL dataset utilities and preflight validation for GRPO."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import math
+from pathlib import Path
+import random
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple, Union
+
+from src.data_utils import create_train_val_split, load_dataset, save_jsonl
+from src.rewards import compute_reward
+
+
+@dataclass
+class RLSchemaValidation:
+    """Validation summary for RL dataset schema quality."""
+
+    total_samples: int
+    valid_samples: int
+    invalid_samples: int
+    duplicate_samples: int
+    missing_prompt: int
+    missing_reference: int
+    min_prompt_length: int
+    min_reference_length: int
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "total_samples": self.total_samples,
+            "valid_samples": self.valid_samples,
+            "invalid_samples": self.invalid_samples,
+            "duplicate_samples": self.duplicate_samples,
+            "missing_prompt": self.missing_prompt,
+            "missing_reference": self.missing_reference,
+            "min_prompt_length": self.min_prompt_length,
+            "min_reference_length": self.min_reference_length,
+        }
+
+
+@dataclass
+class RewardAuditReport:
+    """Reward coverage and numeric stability report."""
+
+    sample_size: int
+    total_reward_mean: float
+    total_reward_std: float
+    total_reward_min: float
+    total_reward_max: float
+    component_stats: Dict[str, Dict[str, float]]
+    has_nan_or_inf: bool
+    has_nonzero_variance: bool
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "sample_size": self.sample_size,
+            "total_reward_mean": self.total_reward_mean,
+            "total_reward_std": self.total_reward_std,
+            "total_reward_min": self.total_reward_min,
+            "total_reward_max": self.total_reward_max,
+            "component_stats": self.component_stats,
+            "has_nan_or_inf": self.has_nan_or_inf,
+            "has_nonzero_variance": self.has_nonzero_variance,
+        }
+
+
+def load_rl_dataset(path: Union[str, Path]) -> List[Dict[str, Any]]:
+    """Load RL dataset from json/jsonl and enforce list semantics."""
+    data = load_dataset(path)
+    if not isinstance(data, list):
+        raise ValueError("RL dataset must be a list of samples")
+    return data
+
+
+def normalize_to_rl_sample(
+    item: Mapping[str, Any],
+    instruction_key: str = "instruction",
+    response_key: str = "response",
+) -> Dict[str, Any]:
+    """Normalize mixed schemas into a strict prompt/reference sample."""
+    prompt = item.get("prompt")
+    reference = item.get("reference")
+
+    if prompt is None:
+        prompt = item.get(instruction_key) or item.get("question") or item.get("input")
+    if reference is None:
+        reference = item.get(response_key) or item.get("answer") or item.get("output")
+
+    metadata = item.get("metadata")
+    if metadata is None:
+        metadata = {}
+
+    return {
+        "prompt": "" if prompt is None else str(prompt),
+        "reference": "" if reference is None else str(reference),
+        "metadata": metadata if isinstance(metadata, dict) else {"raw_metadata": metadata},
+    }
+
+
+def validate_rl_schema(
+    data: Iterable[Mapping[str, Any]],
+    min_prompt_length: int = 3,
+    min_reference_length: int = 1,
+) -> Tuple[List[Dict[str, Any]], RLSchemaValidation]:
+    """Validate prompt/reference schema and return normalized valid samples."""
+    data_list = list(data)
+    normalized: List[Dict[str, Any]] = []
+    seen_pairs = set()
+    duplicate_samples = 0
+    missing_prompt = 0
+    missing_reference = 0
+
+    for raw in data_list:
+        sample = normalize_to_rl_sample(raw)
+        prompt = sample["prompt"].strip()
+        reference = sample["reference"].strip()
+
+        if len(prompt) < min_prompt_length:
+            missing_prompt += 1
+            continue
+        if len(reference) < min_reference_length:
+            missing_reference += 1
+            continue
+
+        key = (prompt, reference)
+        if key in seen_pairs:
+            duplicate_samples += 1
+            continue
+        seen_pairs.add(key)
+        sample["prompt"] = prompt
+        sample["reference"] = reference
+        normalized.append(sample)
+
+    total = len(data_list)
+    valid = len(normalized)
+    invalid = total - valid
+
+    report = RLSchemaValidation(
+        total_samples=total,
+        valid_samples=valid,
+        invalid_samples=invalid,
+        duplicate_samples=duplicate_samples,
+        missing_prompt=missing_prompt,
+        missing_reference=missing_reference,
+        min_prompt_length=min_prompt_length,
+        min_reference_length=min_reference_length,
+    )
+    return normalized, report
+
+
+def _mean(values: List[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _std(values: List[float], mean_value: Optional[float] = None) -> float:
+    if not values:
+        return 0.0
+    m = _mean(values) if mean_value is None else mean_value
+    return (sum((v - m) ** 2 for v in values) / len(values)) ** 0.5
+
+
+def audit_reward_coverage(
+    data: List[Dict[str, Any]],
+    reward_config: Mapping[str, Any],
+    sample_size: int = 128,
+    seed: int = 42,
+) -> RewardAuditReport:
+    """Audit reward distribution and component-level numeric stability."""
+    if not data:
+        raise ValueError("Cannot audit reward coverage on empty dataset")
+
+    rng = random.Random(seed)
+    if len(data) <= sample_size:
+        probe = data[:]
+    else:
+        probe = rng.sample(data, sample_size)
+
+    total_scores: List[float] = []
+    component_values: Dict[str, List[float]] = {}
+    has_nan_or_inf = False
+
+    for idx, sample in enumerate(probe):
+        # Alternate between near-gold and degraded responses to stress reward dynamic range.
+        if idx % 2 == 0:
+            response = sample.get("reference", "")
+        else:
+            response = ""
+
+        out = compute_reward(sample, response, reward_config)
+        total = float(out.total_score)
+        total_scores.append(total)
+
+        if math.isnan(total) or math.isinf(total):
+            has_nan_or_inf = True
+
+        for name, value in out.components.items():
+            component_values.setdefault(name, []).append(float(value))
+            if math.isnan(value) or math.isinf(value):
+                has_nan_or_inf = True
+
+    total_mean = _mean(total_scores)
+    total_std = _std(total_scores, total_mean)
+
+    component_stats: Dict[str, Dict[str, float]] = {}
+    for name, values in component_values.items():
+        mean_v = _mean(values)
+        component_stats[name] = {
+            "mean": mean_v,
+            "std": _std(values, mean_v),
+            "min": min(values) if values else 0.0,
+            "max": max(values) if values else 0.0,
+        }
+
+    return RewardAuditReport(
+        sample_size=len(probe),
+        total_reward_mean=total_mean,
+        total_reward_std=total_std,
+        total_reward_min=min(total_scores) if total_scores else 0.0,
+        total_reward_max=max(total_scores) if total_scores else 0.0,
+        component_stats=component_stats,
+        has_nan_or_inf=has_nan_or_inf,
+        has_nonzero_variance=total_std > 0.0,
+    )
+
+
+def run_grpo_preflight(
+    data: List[Dict[str, Any]],
+    reward_config: Mapping[str, Any],
+    min_prompt_length: int,
+    min_reference_length: int,
+    sample_size: int,
+    seed: int,
+    require_nonzero_variance: bool,
+    min_reward_std: float,
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """Validate RL schema and reward quality before GRPO training."""
+    normalized, schema_report = validate_rl_schema(
+        data,
+        min_prompt_length=min_prompt_length,
+        min_reference_length=min_reference_length,
+    )
+    if not normalized:
+        raise ValueError("GRPO preflight failed: no valid prompt/reference samples")
+
+    audit = audit_reward_coverage(
+        normalized,
+        reward_config=reward_config,
+        sample_size=sample_size,
+        seed=seed,
+    )
+
+    if audit.has_nan_or_inf:
+        raise ValueError("GRPO preflight failed: reward produced NaN/Inf values")
+
+    if require_nonzero_variance and audit.total_reward_std < min_reward_std:
+        raise ValueError(
+            "GRPO preflight failed: reward variance too low "
+            f"(std={audit.total_reward_std:.6f}, required>={min_reward_std:.6f})"
+        )
+
+    report = {
+        "schema": schema_report.to_dict(),
+        "reward_audit": audit.to_dict(),
+    }
+    return normalized, report
+
+
+def convert_to_grpo_format(
+    input_path: Union[str, Path],
+    output_dir: Union[str, Path],
+    val_ratio: float = 0.1,
+    eval_ratio: float = 0.1,
+    instruction_key: str = "instruction",
+    response_key: str = "response",
+) -> Tuple[Path, Path, Path]:
+    """Convert mixed instruction/response or prompt/reference into GRPO files."""
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    raw_data = load_dataset(input_path)
+    normalized = [
+        normalize_to_rl_sample(item, instruction_key=instruction_key, response_key=response_key)
+        for item in raw_data
+    ]
+
+    # First split train+valid from eval.
+    train_valid, eval_data = create_train_val_split(normalized, val_ratio=eval_ratio)
+    train_data, valid_data = create_train_val_split(train_valid, val_ratio=val_ratio)
+
+    train_path = output_dir / "rl_train.jsonl"
+    valid_path = output_dir / "rl_valid.jsonl"
+    eval_path = output_dir / "rl_eval.jsonl"
+
+    save_jsonl(train_data, train_path)
+    save_jsonl(valid_data, valid_path)
+    save_jsonl(eval_data, eval_path)
+
+    print(f"Saved {len(train_data)} RL train samples to {train_path}")
+    print(f"Saved {len(valid_data)} RL valid samples to {valid_path}")
+    print(f"Saved {len(eval_data)} RL eval samples to {eval_path}")
+
+    return train_path, valid_path, eval_path
+
+
+def save_preflight_report(report: Mapping[str, Any], path: Union[str, Path]) -> Path:
+    """Persist preflight report to JSON."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2)
+    return path

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Import config classes directly (no MLX dependency)
 from src.config import (
-    Config, LoRAConfig, TrainingConfig, ModelConfig, 
+    Config, LoRAConfig, TrainingConfig, GRPOConfig, RewardConfig, ModelConfig,
     DataConfig, OutputConfig, HuggingFaceConfig
 )
 
@@ -85,6 +85,36 @@ class TestTrainingConfig:
         assert "save_steps" in d
 
 
+class TestGRPOConfig:
+    """Tests for GRPOConfig class."""
+
+    def test_default_values(self):
+        config = GRPOConfig()
+        assert config.group_size >= 2
+        assert config.beta_kl >= 0.0
+
+    def test_to_dict(self):
+        config = GRPOConfig(group_size=6, beta_kl=0.05)
+        d = config.to_dict()
+        assert d["group_size"] == 6
+        assert d["beta_kl"] == 0.05
+
+
+class TestRewardConfig:
+    """Tests for RewardConfig class."""
+
+    def test_default_values(self):
+        config = RewardConfig()
+        assert config.function == "weighted_rules"
+        assert "exact_match" in config.weights
+
+    def test_to_dict(self):
+        config = RewardConfig(pass_threshold=0.7)
+        d = config.to_dict()
+        assert d["pass_threshold"] == 0.7
+        assert "weights" in d
+
+
 class TestModelConfig:
     """Tests for ModelConfig class."""
     
@@ -109,6 +139,8 @@ class TestConfig:
         config = Config()
         assert isinstance(config.lora, LoRAConfig)
         assert isinstance(config.training, TrainingConfig)
+        assert isinstance(config.grpo, GRPOConfig)
+        assert isinstance(config.reward, RewardConfig)
         assert isinstance(config.model, ModelConfig)
     
     def test_yaml_round_trip(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -16,7 +16,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 # Import config classes directly (no MLX dependency)
 from src.config import (
     Config, LoRAConfig, TrainingConfig, GRPOConfig, RewardConfig, ModelConfig,
-    DataConfig, OutputConfig, HuggingFaceConfig
+    OutputConfig,
 )
 
 # Import data_utils functions directly
@@ -155,6 +155,18 @@ class TestConfig:
         
         assert loaded.lora.rank == 32
         assert loaded.training.learning_rate == 2e-5
+
+    def test_default_yaml_uses_qwen_prompt_tokens_for_qwen_model(self):
+        """The shipped Qwen default config should not inject Llama-only tokens."""
+        config = Config.from_yaml("configs/default.yaml")
+
+        if "qwen" not in config.model.name.lower():
+            pytest.skip("Default config no longer uses a Qwen-family model")
+
+        assert config.data.prompt_template is not None
+        assert "<|im_start|>" in config.data.prompt_template
+        assert "<|start_header_id|>" not in config.data.prompt_template
+        assert "<|begin_of_text|>" not in config.data.prompt_template
 
 
 class TestOutputConfig:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -510,6 +510,19 @@ class TestPreprocessRawText:
         text = "Python was created by Guido van Rossum."
         examples = preprocess_raw_text(text, output_format="knowledge", topic="Python history")
         assert len(examples) >= 0
+
+    def test_remove_speaker_labels_option(self):
+        """Test speaker label removal through the raw preprocessing pipeline."""
+        text = "Speaker 1: This line should keep content but remove the label."
+        examples = preprocess_raw_text(
+            text,
+            output_format="raw",
+            clean_speaker_labels=True,
+        )
+
+        assert examples
+        assert "Speaker 1:" not in examples[0]["text"]
+        assert "This line should keep content" in examples[0]["text"]
     
     def test_raw_format(self):
         """Test raw output format."""

--- a/tests/test_grpo_trainer_math.py
+++ b/tests/test_grpo_trainer_math.py
@@ -1,0 +1,65 @@
+"""Tests for GRPO trainer math helpers."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+def _install_fake_mlx(monkeypatch):
+    fake_mx_core = types.ModuleType("mlx.core")
+    fake_mx_core.array = lambda x: x
+    fake_mx_core.exp = lambda x: x
+    fake_mx_core.clip = lambda x, *_: x
+    fake_mx_core.minimum = min
+    fake_mx_core.logsumexp = lambda x, **kwargs: x
+    fake_mx_core.save_safetensors = lambda *args, **kwargs: None
+    fake_mx_core.load = lambda *args, **kwargs: {}
+    fake_mx_core.eval = lambda *args, **kwargs: None
+
+    fake_nn = types.ModuleType("mlx.nn")
+    fake_nn.Module = object
+    fake_nn.losses = types.SimpleNamespace(cross_entropy=lambda *args, **kwargs: 0.0)
+    fake_nn.value_and_grad = lambda *args, **kwargs: None
+
+    fake_optim = types.ModuleType("mlx.optimizers")
+    fake_optim.AdamW = object
+    fake_utils = types.ModuleType("mlx.utils")
+    fake_utils.tree_map = lambda fn, *trees: trees[0] if trees else None
+
+    fake_mlx = types.ModuleType("mlx")
+    fake_mlx.core = fake_mx_core
+    fake_mlx.nn = fake_nn
+    fake_mlx.optimizers = fake_optim
+    fake_mlx.utils = fake_utils
+
+    monkeypatch.setitem(sys.modules, "mlx", fake_mlx)
+    monkeypatch.setitem(sys.modules, "mlx.core", fake_mx_core)
+    monkeypatch.setitem(sys.modules, "mlx.nn", fake_nn)
+    monkeypatch.setitem(sys.modules, "mlx.optimizers", fake_optim)
+    monkeypatch.setitem(sys.modules, "mlx.utils", fake_utils)
+
+
+def test_group_advantages_have_zero_mean(monkeypatch):
+    _install_fake_mlx(monkeypatch)
+    mod = importlib.reload(importlib.import_module("src.grpo_trainer"))
+
+    rewards = [1.0, 0.0, 0.5, 0.5]
+    adv = mod.GRPOTrainer.compute_group_advantages(rewards)
+
+    assert len(adv) == len(rewards)
+    assert abs(sum(adv)) < 1e-6
+
+
+def test_clipped_policy_objective_respects_clip(monkeypatch):
+    _install_fake_mlx(monkeypatch)
+    mod = importlib.reload(importlib.import_module("src.grpo_trainer"))
+
+    # ratio above clip should clip to 1 + eps for positive advantages.
+    obj = mod.GRPOTrainer.clipped_policy_objective(ratio=3.0, advantage=1.0, clip_epsilon=0.2)
+    assert abs(obj - 1.2) < 1e-9
+
+    # ratio below clip should clip to 1 - eps for negative advantages.
+    obj_neg = mod.GRPOTrainer.clipped_policy_objective(ratio=0.1, advantage=-1.0, clip_epsilon=0.2)
+    assert abs(obj_neg + 0.8) < 1e-9

--- a/tests/test_rewards_rl_data.py
+++ b/tests/test_rewards_rl_data.py
@@ -1,0 +1,112 @@
+"""Tests for reward functions and GRPO data preflight helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+
+from src.rewards import compute_reward
+from src.rl_data import (
+    audit_reward_coverage,
+    convert_to_grpo_format,
+    run_grpo_preflight,
+    validate_rl_schema,
+)
+
+
+def test_compute_reward_exact_match():
+    sample = {"prompt": "2+2", "reference": "4", "metadata": {}}
+    config = {"function": "exact_match", "pass_threshold": 0.5}
+    out = compute_reward(sample, "4", config)
+    assert out.total_score == 1.0
+    assert out.passed
+
+
+def test_compute_reward_weighted_rules_with_keywords():
+    sample = {
+        "prompt": "Give two words",
+        "reference": "alpha beta",
+        "metadata": {"keywords": ["alpha", "beta"]},
+    }
+    config = {
+        "function": "weighted_rules",
+        "weights": {
+            "keyword_coverage": 1.0,
+        },
+        "metadata_keyword_field": "keywords",
+        "pass_threshold": 0.5,
+    }
+    out = compute_reward(sample, "alpha beta", config)
+    assert out.total_score == 1.0
+    assert out.components["keyword_coverage"] == 1.0
+
+
+def test_compute_reward_json_format():
+    sample = {"prompt": "Return JSON", "reference": "{}", "metadata": {}}
+    out_good = compute_reward(sample, '{"a": 1}', {"function": "json_format", "pass_threshold": 0.5})
+    out_bad = compute_reward(sample, "not-json", {"function": "json_format", "pass_threshold": 0.5})
+    assert out_good.total_score == 1.0
+    assert out_bad.total_score == 0.0
+
+
+def test_validate_rl_schema_filters_invalid_and_duplicates():
+    data = [
+        {"prompt": "prompt-1", "reference": "r1"},
+        {"prompt": "prompt-1", "reference": "r1"},  # duplicate
+        {"prompt": "", "reference": "r2"},    # invalid
+    ]
+    normalized, report = validate_rl_schema(data)
+    assert len(normalized) == 1
+    assert report.duplicate_samples == 1
+    assert report.invalid_samples == 2
+
+
+def test_audit_reward_coverage_has_variance():
+    data = [
+        {"prompt": f"p{i}", "reference": f"answer {i}", "metadata": {"keywords": ["answer"]}}
+        for i in range(20)
+    ]
+    audit = audit_reward_coverage(data, reward_config={"function": "weighted_rules"}, sample_size=10)
+    assert audit.sample_size == 10
+    assert audit.total_reward_std >= 0.0
+
+
+def test_run_grpo_preflight_returns_report():
+    data = [
+        {"prompt": f"prompt {i}", "reference": f"reference {i}", "metadata": {"keywords": [f"reference {i}"]}}
+        for i in range(20)
+    ]
+    normalized, report = run_grpo_preflight(
+        data=data,
+        reward_config={
+            "function": "weighted_rules",
+            "weights": {"exact_match": 1.0},
+        },
+        min_prompt_length=3,
+        min_reference_length=1,
+        sample_size=10,
+        seed=42,
+        require_nonzero_variance=False,
+        min_reward_std=1e-8,
+    )
+    assert len(normalized) == 20
+    assert "schema" in report
+    assert "reward_audit" in report
+
+
+def test_convert_to_grpo_format_creates_three_files():
+    data = [{"instruction": f"Q{i}", "response": f"A{i}"} for i in range(40)]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        input_path = Path(tmpdir) / "input.json"
+        output_dir = Path(tmpdir) / "out"
+
+        with open(input_path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+        train_path, valid_path, eval_path = convert_to_grpo_format(input_path, output_dir)
+
+        assert train_path.exists()
+        assert valid_path.exists()
+        assert eval_path.exists()

--- a/tests/test_train_cli_grpo.py
+++ b/tests/test_train_cli_grpo.py
@@ -3,15 +3,19 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 import sys
 import types
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from src.config import Config
 
 
 def _install_fake_mlx(monkeypatch):
     fake_mx_core = types.ModuleType("mlx.core")
+    fake_mx_core.array = object
     fake_nn = types.ModuleType("mlx.nn")
     fake_nn.Module = object
     fake_optim = types.ModuleType("mlx.optimizers")
@@ -48,13 +52,13 @@ def test_cli_dispatches_grpo(monkeypatch, tmp_path):
 
     called = {"grpo": 0}
 
-    def fake_grpo(config, config_path):
+    def fake_grpo(config, config_path, **kwargs):
         called["grpo"] += 1
         return {"mode": "grpo"}
 
     monkeypatch.setattr(module, "run_grpo", fake_grpo)
-    monkeypatch.setattr(module, "run_basic_or_kfold", lambda *_: (_ for _ in ()).throw(AssertionError("unexpected")))
-    monkeypatch.setattr(module, "run_grpo_kfold", lambda *_: (_ for _ in ()).throw(AssertionError("unexpected")))
+    monkeypatch.setattr(module, "run_basic_or_kfold", lambda *_, **__: (_ for _ in ()).throw(AssertionError("unexpected")))
+    monkeypatch.setattr(module, "run_grpo_kfold", lambda *_, **__: (_ for _ in ()).throw(AssertionError("unexpected")))
 
     monkeypatch.setattr(sys, "argv", ["train.py", "--config", str(cfg_path), "--training-method", "grpo"])
     module.main()
@@ -71,15 +75,104 @@ def test_cli_dispatches_grpo_kfold(monkeypatch, tmp_path):
 
     called = {"grpo_kfold": 0}
 
-    def fake_grpo_kfold(config, config_path):
+    def fake_grpo_kfold(config, config_path, **kwargs):
         called["grpo_kfold"] += 1
         return {"mode": "grpo_kfold"}
 
     monkeypatch.setattr(module, "run_grpo_kfold", fake_grpo_kfold)
-    monkeypatch.setattr(module, "run_basic_or_kfold", lambda *_: (_ for _ in ()).throw(AssertionError("unexpected")))
-    monkeypatch.setattr(module, "run_grpo", lambda *_: (_ for _ in ()).throw(AssertionError("unexpected")))
+    monkeypatch.setattr(module, "run_basic_or_kfold", lambda *_, **__: (_ for _ in ()).throw(AssertionError("unexpected")))
+    monkeypatch.setattr(module, "run_grpo", lambda *_, **__: (_ for _ in ()).throw(AssertionError("unexpected")))
 
     monkeypatch.setattr(sys, "argv", ["train.py", "--config", str(cfg_path), "--training-method", "grpo_kfold"])
     module.main()
 
     assert called["grpo_kfold"] == 1
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, str]]) -> None:
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n")
+
+
+def test_cli_dry_run_reports_limited_sft_plan_without_training(monkeypatch, tmp_path, capsys):
+    module = _load_train_module(monkeypatch)
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    train_path = data_dir / "train.jsonl"
+    valid_path = data_dir / "valid.jsonl"
+    _write_jsonl(train_path, [{"text": f"train {i}"} for i in range(3)])
+    _write_jsonl(valid_path, [{"text": f"valid {i}"} for i in range(2)])
+
+    cfg = Config()
+    cfg.data.train_file = str(train_path)
+    cfg.data.valid_file = str(valid_path)
+    cfg.output.dir = str(tmp_path / "outputs")
+    cfg_path = tmp_path / "config.yaml"
+    cfg.to_yaml(str(cfg_path))
+
+    monkeypatch.setattr(module, "run_basic_or_kfold", lambda *_, **__: (_ for _ in ()).throw(AssertionError("unexpected")))
+    monkeypatch.setattr(module, "run_grpo", lambda *_, **__: (_ for _ in ()).throw(AssertionError("unexpected")))
+    monkeypatch.setattr(module, "run_grpo_kfold", lambda *_, **__: (_ for _ in ()).throw(AssertionError("unexpected")))
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "train.py",
+            "--config",
+            str(cfg_path),
+            "--dry-run",
+            "--max-train-samples",
+            "2",
+            "--max-val-samples",
+            "1",
+        ],
+    )
+
+    module.main()
+
+    output = capsys.readouterr().out
+    assert "Dry run complete" in output
+    assert '"training_method": "basic"' in output
+    assert '"loaded_samples": 3' in output
+    assert '"used_samples": 2' in output
+    assert '"loaded_samples": 2' in output
+    assert '"used_samples": 1' in output
+
+
+def test_cli_passes_sample_limits_to_grpo(monkeypatch, tmp_path):
+    module = _load_train_module(monkeypatch)
+
+    cfg = Config()
+    cfg_path = tmp_path / "config.yaml"
+    cfg.to_yaml(str(cfg_path))
+
+    captured = {}
+
+    def fake_grpo(config, config_path, **kwargs):
+        captured.update(kwargs)
+        return {"mode": "grpo"}
+
+    monkeypatch.setattr(module, "run_grpo", fake_grpo)
+    monkeypatch.setattr(module, "run_basic_or_kfold", lambda *_, **__: (_ for _ in ()).throw(AssertionError("unexpected")))
+    monkeypatch.setattr(module, "run_grpo_kfold", lambda *_, **__: (_ for _ in ()).throw(AssertionError("unexpected")))
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "train.py",
+            "--config",
+            str(cfg_path),
+            "--training-method",
+            "grpo",
+            "--max-train-samples",
+            "4",
+            "--max-val-samples",
+            "2",
+        ],
+    )
+    module.main()
+
+    assert captured["max_train_samples"] == 4
+    assert captured["max_val_samples"] == 2

--- a/tests/test_train_cli_grpo.py
+++ b/tests/test_train_cli_grpo.py
@@ -1,0 +1,85 @@
+"""Smoke tests for train CLI dispatch with GRPO modes."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+from src.config import Config
+
+
+def _install_fake_mlx(monkeypatch):
+    fake_mx_core = types.ModuleType("mlx.core")
+    fake_nn = types.ModuleType("mlx.nn")
+    fake_nn.Module = object
+    fake_optim = types.ModuleType("mlx.optimizers")
+    fake_utils = types.ModuleType("mlx.utils")
+    fake_utils.tree_map = lambda fn, *trees: trees[0] if trees else None
+    fake_mx = types.ModuleType("mlx")
+    fake_mx.core = fake_mx_core
+    fake_mx.nn = fake_nn
+    fake_mx.optimizers = fake_optim
+    fake_mx.utils = fake_utils
+    monkeypatch.setitem(sys.modules, "mlx", fake_mx)
+    monkeypatch.setitem(sys.modules, "mlx.core", fake_mx_core)
+    monkeypatch.setitem(sys.modules, "mlx.nn", fake_nn)
+    monkeypatch.setitem(sys.modules, "mlx.optimizers", fake_optim)
+    monkeypatch.setitem(sys.modules, "mlx.utils", fake_utils)
+
+
+def _load_train_module(monkeypatch):
+    _install_fake_mlx(monkeypatch)
+    train_path = Path(__file__).parent.parent / "scripts" / "train.py"
+    spec = importlib.util.spec_from_file_location("train_script_module", str(train_path))
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cli_dispatches_grpo(monkeypatch, tmp_path):
+    module = _load_train_module(monkeypatch)
+
+    cfg = Config()
+    cfg_path = tmp_path / "config.yaml"
+    cfg.to_yaml(str(cfg_path))
+
+    called = {"grpo": 0}
+
+    def fake_grpo(config, config_path):
+        called["grpo"] += 1
+        return {"mode": "grpo"}
+
+    monkeypatch.setattr(module, "run_grpo", fake_grpo)
+    monkeypatch.setattr(module, "run_basic_or_kfold", lambda *_: (_ for _ in ()).throw(AssertionError("unexpected")))
+    monkeypatch.setattr(module, "run_grpo_kfold", lambda *_: (_ for _ in ()).throw(AssertionError("unexpected")))
+
+    monkeypatch.setattr(sys, "argv", ["train.py", "--config", str(cfg_path), "--training-method", "grpo"])
+    module.main()
+
+    assert called["grpo"] == 1
+
+
+def test_cli_dispatches_grpo_kfold(monkeypatch, tmp_path):
+    module = _load_train_module(monkeypatch)
+
+    cfg = Config()
+    cfg_path = tmp_path / "config.yaml"
+    cfg.to_yaml(str(cfg_path))
+
+    called = {"grpo_kfold": 0}
+
+    def fake_grpo_kfold(config, config_path):
+        called["grpo_kfold"] += 1
+        return {"mode": "grpo_kfold"}
+
+    monkeypatch.setattr(module, "run_grpo_kfold", fake_grpo_kfold)
+    monkeypatch.setattr(module, "run_basic_or_kfold", lambda *_: (_ for _ in ()).throw(AssertionError("unexpected")))
+    monkeypatch.setattr(module, "run_grpo", lambda *_: (_ for _ in ()).throw(AssertionError("unexpected")))
+
+    monkeypatch.setattr(sys, "argv", ["train.py", "--config", str(cfg_path), "--training-method", "grpo_kfold"])
+    module.main()
+
+    assert called["grpo_kfold"] == 1


### PR DESCRIPTION
## Summary
- add end-to-end GRPO training support with RL preflight, SFT warmup, K-fold mode, and post-evaluation
- add dry-run and sample-limit controls for small smoke tests before expensive MLX runs
- align the default Qwen prompt template with Qwen chat delimiters
- wire speaker-label cleanup through raw-text preprocessing paths

## Why
This brings the GRPO branch into the default product path and preserves safer iteration defaults for small-batch testing with MLX models.

Closes #2.

## Validation
- pytest -q
- dry-run smoke validation with mlx-community/Qwen3.5-4B-OptiQ-4bit during PR #9
